### PR TITLE
Add node names to data instead of metadata

### DIFF
--- a/internal/shared-types/src/graph.ts
+++ b/internal/shared-types/src/graph.ts
@@ -5,6 +5,7 @@ export type GraphNode = {
     id: string;
     type: string;
     parent?: string;
+    name?: string;
   };
   metadata?: any;
 };

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infrascan/sdk",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Tool to generate a system map by connecting to your AWS account.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk/src/graph.ts
+++ b/packages/sdk/src/graph.ts
@@ -42,6 +42,7 @@ function formatIdAsNode(
       id: formattedId,
       type: serviceKey,
       parent: metadata?.parent,
+      name: metadata?.name,
     },
     metadata,
   };


### PR DESCRIPTION
Node names were incorrectly being inserted into metadata which can't be pulled from cytoscape. Update shared types to include optional string value for name in data object.