### PR TITLE
Add middleware to handle S3 not found errors

### DIFF
--- a/.changeset/cold-buttons-double.md
+++ b/.changeset/cold-buttons-double.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/aws-s3-scanner": patch
+---
+
+Add middleware to silence not found errors when scanning s3 bucket tag sets and website configs

--- a/aws-scanners/s3/package.json
+++ b/aws-scanners/s3/package.json
@@ -61,6 +61,7 @@
     "@infrascan/aws-codegen": "^0.1.0",
     "@infrascan/fs-connector": "^0.2.2",
     "@infrascan/shared-types": "^0.2.2",
+    "@smithy/types": "^2.4.0",
     "aws-sdk-client-mock": "^3.0.0",
     "eslint-config-codegen": "^1.0.0",
     "tsconfig": "^0.0.0"

--- a/aws-scanners/s3/src/index.ts
+++ b/aws-scanners/s3/src/index.ts
@@ -16,16 +16,19 @@ import {
   GetBucketAcl,
 } from "./generated/getters";
 import { getNodes, getEdges } from "./generated/graph";
+import { registerMiddleware } from "./middleware";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
 ): S3Client {
-  return new S3Client({
+  const s3Client = new S3Client({
     credentials,
     region: context.region,
-    followRegionRedirects: true
+    followRegionRedirects: true,
   });
+  registerMiddleware(s3Client);
+  return s3Client;
 }
 
 // Format S3 ID as arn in place of bucket name

--- a/aws-scanners/s3/src/middleware.ts
+++ b/aws-scanners/s3/src/middleware.ts
@@ -1,0 +1,78 @@
+import type {
+  FinalizeHandler,
+  FinalizeHandlerArguments,
+  FinalizeHandlerOutput,
+  HandlerExecutionContext,
+} from "@smithy/types";
+import {
+  S3Client,
+  ServiceInputTypes,
+  ServiceOutputTypes,
+  S3ServiceException,
+  _Error,
+} from "@aws-sdk/client-s3";
+
+/**
+ * The class for errors from S3 doesn't include the Code used to identify the Errors, unlike the public `_Error` interface does.
+ * To safely ignore the known errors in `ignoreS3ConfigNotFoundErrors`, we need to assert that the error being thrown has the correct interface.
+ */
+function isRichError(
+  err: S3ServiceException & { Code?: string },
+): err is _Error & S3ServiceException {
+  return err.Code != null;
+}
+
+/**
+ * The S3 Client throws a resource not found in some cases when fetching optional config relating to a bucket
+ * (e.g. GetBucketTaggingCommand, and GetBucketWebsiteCommand). In the case of a scanner, it's more useful to
+ * receive an empty object response than it is to error. This middleware will catch errors and, where appropriate,
+ * return an empty object instead.
+ */
+function ignoreS3ConfigNotFoundErrors(
+  next: FinalizeHandler<ServiceInputTypes, ServiceOutputTypes>,
+  context: HandlerExecutionContext,
+): FinalizeHandler<ServiceInputTypes, ServiceOutputTypes> {
+  return async function mapNotFoundErrors(
+    args: FinalizeHandlerArguments<ServiceInputTypes>,
+  ): Promise<FinalizeHandlerOutput<ServiceOutputTypes>> {
+    try {
+      return await next(args);
+    } catch (err: unknown) {
+      if (err instanceof S3ServiceException && isRichError(err)) {
+        if (
+          context.commandName === "GetBucketTaggingCommand" &&
+          err.Code === "NoSuchTagSet"
+        ) {
+          return {
+            output: {
+              $metadata: {},
+              TagSet: [],
+            },
+            response: err,
+          };
+        }
+        if (
+          context.commandName === "GetBucketWebsiteCommand" &&
+          err.Code === "NoSuchWebsiteConfiguration"
+        ) {
+          return {
+            output: {
+              $metadata: {},
+            },
+            response: err,
+          };
+        }
+      }
+      throw err;
+    }
+  };
+}
+
+export function registerMiddleware(client: S3Client) {
+  client.middlewareStack.add(ignoreS3ConfigNotFoundErrors, {
+    step: "finalizeRequest",
+    name: "ignoreS3ConfigNotFoundErrors",
+    tags: ["ErrorHandling"],
+    priority: "high",
+  });
+}

--- a/aws-scanners/s3/src/middleware.ts
+++ b/aws-scanners/s3/src/middleware.ts
@@ -12,14 +12,55 @@ import {
   _Error,
 } from "@aws-sdk/client-s3";
 
+export type RichError = S3ServiceException & _Error;
+
 /**
  * The class for errors from S3 doesn't include the Code used to identify the Errors, unlike the public `_Error` interface does.
  * To safely ignore the known errors in `ignoreS3ConfigNotFoundErrors`, we need to assert that the error being thrown has the correct interface.
  */
 function isRichError(
   err: S3ServiceException & { Code?: string },
-): err is _Error & S3ServiceException {
+): err is RichError {
   return err.Code != null;
+}
+
+export function mapNotFoundErrorToEmptyResponse(
+  context: HandlerExecutionContext,
+  err: unknown,
+): FinalizeHandlerOutput<ServiceOutputTypes> | undefined {
+  const isRichS3Err = err instanceof S3ServiceException && isRichError(err);
+  if (!isRichS3Err) {
+    console.log("Not a rich error", err);
+    return undefined;
+  }
+
+  // Map NoSuchTagSet to empty TagSet
+  if (
+    context.commandName === "GetBucketTaggingCommand" &&
+    err.Code === "NoSuchTagSet"
+  ) {
+    return {
+      output: {
+        $metadata: {},
+        TagSet: [],
+      },
+      response: err,
+    };
+  }
+  // Map NoSuchWebsiteConfig to empty response
+  if (
+    context.commandName === "GetBucketWebsiteCommand" &&
+    err.Code === "NoSuchWebsiteConfiguration"
+  ) {
+    return {
+      output: {
+        $metadata: {},
+      },
+      response: err,
+    };
+  }
+
+  return undefined;
 }
 
 /**
@@ -28,7 +69,7 @@ function isRichError(
  * receive an empty object response than it is to error. This middleware will catch errors and, where appropriate,
  * return an empty object instead.
  */
-function ignoreS3ConfigNotFoundErrors(
+function ignoreS3ConfigNotFoundMiddleware(
   next: FinalizeHandler<ServiceInputTypes, ServiceOutputTypes>,
   context: HandlerExecutionContext,
 ): FinalizeHandler<ServiceInputTypes, ServiceOutputTypes> {
@@ -38,30 +79,9 @@ function ignoreS3ConfigNotFoundErrors(
     try {
       return await next(args);
     } catch (err: unknown) {
-      if (err instanceof S3ServiceException && isRichError(err)) {
-        if (
-          context.commandName === "GetBucketTaggingCommand" &&
-          err.Code === "NoSuchTagSet"
-        ) {
-          return {
-            output: {
-              $metadata: {},
-              TagSet: [],
-            },
-            response: err,
-          };
-        }
-        if (
-          context.commandName === "GetBucketWebsiteCommand" &&
-          err.Code === "NoSuchWebsiteConfiguration"
-        ) {
-          return {
-            output: {
-              $metadata: {},
-            },
-            response: err,
-          };
-        }
+      const mappedResponse = mapNotFoundErrorToEmptyResponse(context, err);
+      if (mappedResponse != null) {
+        return mappedResponse;
       }
       throw err;
     }
@@ -69,7 +89,7 @@ function ignoreS3ConfigNotFoundErrors(
 }
 
 export function registerMiddleware(client: S3Client) {
-  client.middlewareStack.add(ignoreS3ConfigNotFoundErrors, {
+  client.middlewareStack.add(ignoreS3ConfigNotFoundMiddleware, {
     step: "finalizeRequest",
     name: "ignoreS3ConfigNotFoundErrors",
     tags: ["ErrorHandling"],

--- a/aws-scanners/s3/test/middleware.test.ts
+++ b/aws-scanners/s3/test/middleware.test.ts
@@ -1,0 +1,93 @@
+import {
+  GetBucketTaggingCommandOutput,
+  GetBucketWebsiteCommandOutput,
+  S3ServiceException,
+} from "@aws-sdk/client-s3";
+import t from "tap";
+import { mapNotFoundErrorToEmptyResponse, RichError } from "../src/middleware";
+
+function buildRichS3Error(err: { Code: string }): RichError {
+  const exception = new S3ServiceException({
+    name: err.Code,
+    $fault: "client",
+    $metadata: {},
+  });
+  return Object.assign(exception, { Code: err.Code });
+}
+
+t.test("MapNotFoundErrorToEmptyResponse", (tap) => {
+  tap.plan(6);
+  tap.test("NoSuchTagSet returns empty response", ({ ok, equal, end }) => {
+    const response = mapNotFoundErrorToEmptyResponse(
+      { commandName: "GetBucketTaggingCommand" },
+      buildRichS3Error({ Code: "NoSuchTagSet" }),
+    );
+
+    ok(response);
+    const emptyResponse = response?.output as GetBucketTaggingCommandOutput;
+    equal(emptyResponse.TagSet?.length, 0);
+    end();
+  });
+
+  tap.test("Unmapped error code returns undefined", ({ equal, end }) => {
+    const response = mapNotFoundErrorToEmptyResponse(
+      { commandName: "GetBucketTaggingCommand" },
+      buildRichS3Error({ Code: "BucketNotFound" }),
+    );
+
+    equal(response, undefined);
+    end();
+  });
+
+  tap.test(
+    "NoSuchWebsiteConfiguration returns an empty response",
+    ({ ok, notOk, end }) => {
+      const response = mapNotFoundErrorToEmptyResponse(
+        { commandName: "GetBucketWebsiteCommand" },
+        buildRichS3Error({ Code: "NoSuchWebsiteConfiguration" }),
+      );
+
+      ok(response);
+      const emptyResponse = response?.output as GetBucketWebsiteCommandOutput;
+      ok(emptyResponse.$metadata);
+      notOk(emptyResponse.IndexDocument);
+      end();
+    },
+  );
+
+  tap.test("Unmapped error code returns undefined", ({ equal, end }) => {
+    const response = mapNotFoundErrorToEmptyResponse(
+      { commandName: "GetBucketWebsiteCommand" },
+      buildRichS3Error({ Code: "BucketNotFound" }),
+    );
+
+    equal(response, undefined);
+    end();
+  });
+
+  tap.test(
+    "Unmapped command's error code returns undefined",
+    ({ equal, end }) => {
+      const response = mapNotFoundErrorToEmptyResponse(
+        { commandName: "ListBucketsCommand" },
+        buildRichS3Error({ Code: "Forbidden" }),
+      );
+
+      equal(response, undefined);
+      end();
+    },
+  );
+
+  tap.test(
+    "Basic service exception without standard code returns undefined",
+    ({ equal, end }) => {
+      const response = mapNotFoundErrorToEmptyResponse(
+        { commandName: "ListBucketsCommand" },
+        buildRichS3Error({ Code: "Forbidden" }),
+      );
+
+      equal(response, undefined);
+      end();
+    },
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1158,6 +1158,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
         "@infrascan/shared-types": "^0.2.2",
+        "@smithy/types": "^2.4.0",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -23342,6 +23343,7 @@
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
         "@infrascan/shared-types": "^0.2.2",
+        "@smithy/types": "*",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -41,6 +41,7 @@ function resolveCredentials(
         RoleArn: roleToAssume,
         RoleSessionName: "infrascan-cli-scan",
       },
+      clientConfig: { region: undefined },
     });
   }
   throw new Error(

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -41,7 +41,6 @@ function resolveCredentials(
         RoleArn: roleToAssume,
         RoleSessionName: "infrascan-cli-scan",
       },
-      clientConfig: { region: undefined },
     });
   }
   throw new Error(


### PR DESCRIPTION
The S3 client throws command specific, unretryable errors for GetWebsiteConfiguration, and GetBucketTagging. When scanning an account, we cannot tell in advance if a bucket will or will not have a website config, or tag set. 

This PR aims to avoid noise in logs from errors thrown when scanning S3. The s3 client builder adds a `finalizeRequest` [middleware](https://aws.amazon.com/blogs/developer/middleware-stack-modular-aws-sdk-js/). The middleware passes the request through as normal, but catches the errors thrown from the client's internals and maps `NoSuchTagSet` and `NoSuchWebsiteConfiguration` to empty responses to allow a scan to proceed.