### PR TITLE
Fix: Update ECS state selectors to skip empty lists in parameters

### DIFF
--- a/.changeset/violet-mangos-nail.md
+++ b/.changeset/violet-mangos-nail.md
@@ -1,0 +1,8 @@
+---
+"@infrascan/shared-types": patch
+"@infrascan/aws-ecs-scanner": patch
+---
+
+Update ECS Scanner to filter out empty lists when pulling parameters. 
+
+Remove unused key in shared-types scanner definitions.

--- a/aws-scanners/cloudwatch-logs/test/index.test.ts
+++ b/aws-scanners/cloudwatch-logs/test/index.test.ts
@@ -96,3 +96,44 @@ t.test(
     }
   },
 );
+
+t.test("No Log groups returned from DescribeLogGroups command", async () => {
+  const testContext = {
+    region: "us-east-1",
+    account: "0".repeat(8),
+  };
+  const cloudwatchLogsClient = CloudwatchLogsScanner.getClient(
+    fromProcess(),
+    testContext,
+  );
+
+  const mockedCloudwatchLogsClient = mockClient(cloudwatchLogsClient);
+
+  // Mock each of the functions used to pull state
+  mockedCloudwatchLogsClient.on(DescribeLogGroupsCommand).resolves({
+    logGroups: [],
+  });
+
+  for (const scannerFn of CloudwatchLogsScanner.getters) {
+    await scannerFn(cloudwatchLogsClient, connector, testContext);
+  }
+
+  const logGroupCallCount = mockedCloudwatchLogsClient.commandCalls(
+    DescribeLogGroupsCommand,
+  ).length;
+  t.equal(logGroupCallCount, 1);
+  const subscriptionCallCount = mockedCloudwatchLogsClient.commandCalls(
+    DescribeSubscriptionFiltersCommand,
+  ).length;
+  t.equal(subscriptionCallCount, 0);
+
+  if (CloudwatchLogsScanner.getNodes != null) {
+    const nodes = await CloudwatchLogsScanner.getNodes(connector, testContext);
+    t.equal(nodes.length, 0);
+  }
+
+  if (CloudwatchLogsScanner.getEdges != null) {
+    const edges = await CloudwatchLogsScanner.getEdges(connector);
+    t.equal(edges.length, 0);
+  }
+});

--- a/aws-scanners/ecs/config.ts
+++ b/aws-scanners/ecs/config.ts
@@ -27,7 +27,8 @@ const ECSScanner: ScannerDefinition<"ECS", typeof ECS, ECSFunctions> = {
       parameters: [
         {
           Key: "clusters",
-          Selector: "ECS|ListClusters|[]._result.clusterArns",
+          Selector:
+            "ECS|ListClusters|[]._result.clusterArns | [?length(@)>`0`]",
         },
         {
           Key: "include",
@@ -63,7 +64,8 @@ const ECSScanner: ScannerDefinition<"ECS", typeof ECS, ECSFunctions> = {
         },
         {
           Key: "services",
-          Selector: "ECS|ListServices|[]._result.serviceArns",
+          Selector:
+            "ECS|ListServices|[]._result.serviceArns | [?length(@)>`0`]",
         },
         {
           Key: "include",
@@ -89,7 +91,7 @@ const ECSScanner: ScannerDefinition<"ECS", typeof ECS, ECSFunctions> = {
         },
         {
           Key: "tasks",
-          Selector: "ECS|ListTasks|[]._result.taskArns",
+          Selector: "ECS|ListTasks|[]._result.taskArns | [?length(@)>`0`]",
         },
       ],
     },
@@ -104,10 +106,6 @@ const ECSScanner: ScannerDefinition<"ECS", typeof ECS, ECSFunctions> = {
           Key: "include",
           Value: ["TAGS"],
         },
-      ],
-      iamRoleSelectors: [
-        "taskDefinition.taskRoleArn",
-        "taskDefinition.executionRoleArn",
       ],
     },
   ],

--- a/aws-scanners/ecs/src/generated/getters.ts
+++ b/aws-scanners/ecs/src/generated/getters.ts
@@ -80,7 +80,10 @@ export async function DescribeClusters(
   const state: GenericState[] = [];
   console.log("ecs DescribeClusters");
   const resolvers = [
-    { Key: "clusters", Selector: "ECS|ListClusters|[]._result.clusterArns" },
+    {
+      Key: "clusters",
+      Selector: "ECS|ListClusters|[]._result.clusterArns | [?length(@)>`0`]",
+    },
     {
       Key: "include",
       Value: [
@@ -186,7 +189,10 @@ export async function DescribeServices(
   console.log("ecs DescribeServices");
   const resolvers = [
     { Key: "cluster", Selector: "ECS|ListServices|[]._parameters.cluster" },
-    { Key: "services", Selector: "ECS|ListServices|[]._result.serviceArns" },
+    {
+      Key: "services",
+      Selector: "ECS|ListServices|[]._result.serviceArns | [?length(@)>`0`]",
+    },
     { Key: "include", Value: ["TAGS"] },
   ];
   const parameterQueue = (await resolveFunctionCallParameters(
@@ -282,7 +288,10 @@ export async function DescribeTasks(
   console.log("ecs DescribeTasks");
   const resolvers = [
     { Key: "cluster", Selector: "ECS|ListTasks|[]._parameters.cluster" },
-    { Key: "tasks", Selector: "ECS|ListTasks|[]._result.taskArns" },
+    {
+      Key: "tasks",
+      Selector: "ECS|ListTasks|[]._result.taskArns | [?length(@)>`0`]",
+    },
   ];
   const parameterQueue = (await resolveFunctionCallParameters(
     context.account,

--- a/aws-scanners/ecs/test/index.test.ts
+++ b/aws-scanners/ecs/test/index.test.ts
@@ -171,3 +171,222 @@ t.test(
     }
   },
 );
+
+t.test("No Clusters in the account, should skip subsequent calls", async () => {
+  const testContext = {
+    region: "us-east-1",
+    account: "0".repeat(8),
+  };
+  const ecsClient = ECSScanner.getClient(fromProcess(), testContext);
+
+  const mockedEcsClient = mockClient(ecsClient);
+
+  // Mock each of the functions used to pull state
+  mockedEcsClient.on(ListClustersCommand).resolves({
+    clusterArns: [],
+  });
+
+  for (const scannerFn of ECSScanner.getters) {
+    await scannerFn(ecsClient, connector, testContext);
+  }
+
+  t.equal(mockedEcsClient.commandCalls(ListClustersCommand).length, 1);
+  t.equal(mockedEcsClient.commandCalls(DescribeClustersCommand).length, 0);
+  t.equal(mockedEcsClient.commandCalls(ListServicesCommand).length, 0);
+  // Scanner should skip ListServices if no services given
+  t.equal(mockedEcsClient.commandCalls(DescribeServicesCommand).length, 0);
+  t.equal(mockedEcsClient.commandCalls(ListTasksCommand).length, 0);
+  t.equal(mockedEcsClient.commandCalls(DescribeTasksCommand).length, 0);
+  t.equal(
+    mockedEcsClient.commandCalls(DescribeTaskDefinitionCommand).length,
+    0,
+  );
+
+  if (ECSScanner.getNodes != null) {
+    const nodes = await ECSScanner.getNodes(connector, testContext);
+    t.equal(nodes.length, 0);
+  }
+
+  if (ECSScanner.getIamRoles != null) {
+    const iamRoles = await ECSScanner.getIamRoles(connector);
+    t.equal(iamRoles.length, 0);
+  }
+});
+
+t.test("No Services defined in the ECS Cluster", async () => {
+  const testContext = {
+    region: "us-east-1",
+    account: "0".repeat(8),
+  };
+  const ecsClient = ECSScanner.getClient(fromProcess(), testContext);
+
+  const mockedEcsClient = mockClient(ecsClient);
+
+  // Mock each of the functions used to pull state
+  const clusterName = "test-cluster";
+  const clusterArn = `arn:aws:ecs:${testContext.region}:${testContext.account}:cluster/${clusterName}`;
+  mockedEcsClient.on(ListClustersCommand).resolves({
+    clusterArns: [clusterArn],
+  });
+
+  mockedEcsClient.on(DescribeClustersCommand).resolves({
+    clusters: [
+      {
+        clusterName,
+        clusterArn,
+      },
+    ],
+  });
+
+  mockedEcsClient.on(ListServicesCommand).resolves({
+    serviceArns: [],
+  });
+
+  const taskArn = `arn:aws:ecs:${testContext.region}:${testContext.account}:task/${clusterName}/test-task`;
+  mockedEcsClient.on(ListTasksCommand).resolves({
+    taskArns: [taskArn],
+  });
+
+  const executionRoleArn = `arn:aws:iam::${testContext.account}:role/test-exec-role`;
+  const taskRoleArn = `arn:aws:iam::${testContext.account}:role/test-task-role`;
+  const scheduledTaskDefArn = `arn:aws:ecs:${testContext.region}:${testContext.account}:task-definition/scheduled:1`;
+  mockedEcsClient.on(DescribeTasksCommand).resolves({
+    tasks: [
+      {
+        taskArn,
+        taskDefinitionArn: scheduledTaskDefArn,
+        clusterArn,
+      },
+    ],
+  });
+
+  mockedEcsClient.on(DescribeTaskDefinitionCommand).resolves({
+    taskDefinition: {
+      taskRoleArn,
+      executionRoleArn,
+      taskDefinitionArn: scheduledTaskDefArn,
+    },
+  });
+
+  for (const scannerFn of ECSScanner.getters) {
+    await scannerFn(ecsClient, connector, testContext);
+  }
+
+  t.equal(mockedEcsClient.commandCalls(ListClustersCommand).length, 1);
+  t.equal(mockedEcsClient.commandCalls(DescribeClustersCommand).length, 1);
+  t.equal(mockedEcsClient.commandCalls(ListServicesCommand).length, 1);
+  // Scanner should skip ListServices if no services given
+  t.equal(mockedEcsClient.commandCalls(DescribeServicesCommand).length, 0);
+  t.equal(mockedEcsClient.commandCalls(ListTasksCommand).length, 1);
+  t.equal(mockedEcsClient.commandCalls(DescribeTasksCommand).length, 1);
+  t.equal(
+    mockedEcsClient.commandCalls(DescribeTaskDefinitionCommand).length,
+    1,
+  );
+
+  if (ECSScanner.getNodes != null) {
+    const nodes = await ECSScanner.getNodes(connector, testContext);
+    t.equal(nodes.length, 2);
+    // successfully found cluster node
+    t.ok(
+      nodes.find(
+        (node) => node.id === clusterArn && node.data.type === "ECS-Cluster",
+      ),
+    );
+
+    // successfully found task node with cluster as parent
+    t.ok(
+      nodes.find(
+        (node) =>
+          node.id === scheduledTaskDefArn &&
+          node.data.parent === clusterArn &&
+          node.data.type === "ECS-Task",
+      ),
+    );
+  }
+
+  if (ECSScanner.getIamRoles != null) {
+    const iamRoles = await ECSScanner.getIamRoles(connector);
+    t.equal(iamRoles.length, 2);
+    t.ok(
+      iamRoles.find(
+        (role) =>
+          role.executor === scheduledTaskDefArn && role.roleArn === taskRoleArn,
+      ),
+    );
+
+    t.ok(
+      iamRoles.find(
+        (role) =>
+          role.executor === scheduledTaskDefArn &&
+          role.roleArn === executionRoleArn,
+      ),
+    );
+  }
+});
+
+t.test("No Tasks found in the cluster", async () => {
+  const testContext = {
+    region: "us-east-1",
+    account: "0".repeat(8),
+  };
+  const ecsClient = ECSScanner.getClient(fromProcess(), testContext);
+
+  const mockedEcsClient = mockClient(ecsClient);
+
+  // Mock each of the functions used to pull state
+  const clusterName = "test-cluster";
+  const clusterArn = `arn:aws:ecs:${testContext.region}:${testContext.account}:cluster/${clusterName}`;
+  mockedEcsClient.on(ListClustersCommand).resolves({
+    clusterArns: [clusterArn],
+  });
+
+  mockedEcsClient.on(DescribeClustersCommand).resolves({
+    clusters: [
+      {
+        clusterName,
+        clusterArn,
+      },
+    ],
+  });
+
+  mockedEcsClient.on(ListServicesCommand).resolves({
+    serviceArns: [],
+  });
+
+  mockedEcsClient.on(ListTasksCommand).resolves({
+    taskArns: [],
+  });
+
+  for (const scannerFn of ECSScanner.getters) {
+    await scannerFn(ecsClient, connector, testContext);
+  }
+
+  t.equal(mockedEcsClient.commandCalls(ListClustersCommand).length, 1);
+  t.equal(mockedEcsClient.commandCalls(DescribeClustersCommand).length, 1);
+  t.equal(mockedEcsClient.commandCalls(ListServicesCommand).length, 1);
+  // Scanner should skip ListServices if no services given
+  t.equal(mockedEcsClient.commandCalls(DescribeServicesCommand).length, 0);
+  t.equal(mockedEcsClient.commandCalls(ListTasksCommand).length, 1);
+  t.equal(mockedEcsClient.commandCalls(DescribeTasksCommand).length, 0);
+  t.equal(
+    mockedEcsClient.commandCalls(DescribeTaskDefinitionCommand).length,
+    0,
+  );
+
+  if (ECSScanner.getNodes != null) {
+    const nodes = await ECSScanner.getNodes(connector, testContext);
+    t.equal(nodes.length, 1);
+    // successfully found cluster node
+    t.ok(
+      nodes.find(
+        (node) => node.id === clusterArn && node.data.type === "ECS-Cluster",
+      ),
+    );
+  }
+
+  if (ECSScanner.getIamRoles != null) {
+    const iamRoles = await ECSScanner.getIamRoles(connector);
+    t.equal(iamRoles.length, 0);
+  }
+});

--- a/packages/shared-types/src/config.ts
+++ b/packages/shared-types/src/config.ts
@@ -15,10 +15,9 @@ export type BaseGetter = {
   id?: string;
   fn: string;
   /* eslint-disable @typescript-eslint/no-explicit-any */
-  parameters?: (BaseParameterResolver & { Value?: any, Selector?: string })[];
+  parameters?: (BaseParameterResolver & { Value?: any; Selector?: string })[];
   formatter?: string;
   paginationToken?: PaginationToken;
-  iamRoleSelectors?: string[];
 };
 
 export type GenericNodeSelector = `${string}|${string}|${string}`;
@@ -39,7 +38,7 @@ export type BaseScannerDefinition = {
   callPerRegion: boolean;
   // Scanner functions for pulling state from a service
   getters: BaseGetter[];
-  // Scrapers for pulling Nodes from service state 
+  // Scrapers for pulling Nodes from service state
   nodes?: GenericNodeSelector[];
   // Scrapers for pulling Edges from service state
   edges?: BaseEdgeResolver[];
@@ -112,7 +111,6 @@ export type ServiceGetter<
   fn: AvailableCommand<Serv, Funcs>;
   paginationToken?: PaginationToken;
   parameters?: ParameterResolver<ServiceName, Serv, Funcs>[];
-  iamRoleSelectors?: string[];
 };
 
 export type ScannerDefinition<


### PR DESCRIPTION
The ECS Scanner was blindly passing the Cluster and Service arns returned from `ListClusters` and `ListServices`. In cases where they returned empty lists, their dependent function calls would be run with an empty list (due to the functions taking a number of clusters or services in each call). The dependent functions would then result in a bad request.

This PR updates the Selectors in the ECS Scanner config to out empty lists, as well as updating the tests for every scanner to account for the potential of a function returning no state.