### PR TITLE
Support credential factories

### DIFF
--- a/.changeset/kind-seals-divide.md
+++ b/.changeset/kind-seals-divide.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/sdk": minor
+---
+
+Add support for credential provider factories to pass region into the providers client config.

--- a/.changeset/kind-seals-divide.md
+++ b/.changeset/kind-seals-divide.md
@@ -2,4 +2,6 @@
 "@infrascan/sdk": minor
 ---
 
-Add support for credential provider factories to pass region into the providers client config.
+In cases where the AWS Config ini file didn't define a default region, scans would exit early. This was due to the IAM client not supplying a region in its constructor, which introduced a hard dependency on the config file to provide a default. The same dependency existed when creating credential providers. 
+
+This PR patches the IAM client creation in the SDK, and updates its API to accept a credential provider factory which prevents the SDK from failing in inadequately configured environments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -601,7 +601,7 @@
     },
     "aws-scanners/ecs": {
       "name": "@infrascan/aws-ecs-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ecs": "3.428.0",
@@ -611,7 +611,7 @@
         "@aws-sdk/credential-providers": "^3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.3",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -1147,7 +1147,7 @@
     },
     "aws-scanners/s3": {
       "name": "@infrascan/aws-s3-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "3.428.0",
@@ -1157,7 +1157,7 @@
         "@aws-sdk/credential-providers": "^3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.3",
         "@smithy/types": "^2.4.0",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
@@ -18258,7 +18258,7 @@
     },
     "packages/aws": {
       "name": "@infrascan/aws",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@infrascan/aws-api-gateway-scanner": "^0.2.2",
@@ -18284,14 +18284,15 @@
     },
     "packages/cli": {
       "name": "@infrascan/cli",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "3.428.0",
-        "@infrascan/aws": "^0.2.1",
+        "@infrascan/aws": "^0.3.0",
         "@infrascan/fs-connector": "^0.2.2",
         "@infrascan/sdk": "^0.2.2",
         "@rushstack/ts-command-line": "^4.15.2",
+        "@smithy/shared-ini-file-loader": "^2.2.2",
         "minimatch": "^6.1.6"
       },
       "bin": {
@@ -18385,7 +18386,7 @@
     },
     "packages/shared-types": {
       "name": "@infrascan/shared-types",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "devDependencies": {
         "@aws-sdk/types": "3.428.0",
@@ -22902,7 +22903,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.3",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -23342,8 +23343,8 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
-        "@smithy/types": "*",
+        "@infrascan/shared-types": "^0.2.3",
+        "@smithy/types": "^2.4.0",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -23382,11 +23383,12 @@
       "requires": {
         "@aws-sdk/credential-providers": "3.428.0",
         "@aws-sdk/types": "3.428.0",
-        "@infrascan/aws": "^0.2.1",
+        "@infrascan/aws": "^0.3.0",
         "@infrascan/fs-connector": "^0.2.2",
         "@infrascan/sdk": "^0.2.2",
         "@infrascan/shared-types": "^0.2.2",
         "@rushstack/ts-command-line": "^4.15.2",
+        "@smithy/shared-ini-file-loader": "^2.2.2",
         "minimatch": "^6.1.6",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.3"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "@infrascan/fs-connector": "^0.2.2",
     "@infrascan/sdk": "^0.2.2",
     "@rushstack/ts-command-line": "^4.15.2",
+    "@smithy/shared-ini-file-loader": "^2.2.2",
     "minimatch": "^6.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
In cases where the AWS Config ini file didn't define a default region, scans would exit early. This was due to the IAM client not supplying a region in its constructor, which introduced a hard dependency on the config file to provide a default. The same dependency existed when creating credential providers. 

This PR patches the IAM client creation in the SDK, and updates its API to accept a credential provider factory which prevents the SDK from failing in inadequately configured environments.