### PR TITLE
feat: add support for no config file to speed up testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18278,19 +18278,19 @@
         "@infrascan/aws-sqs-scanner": "^0.2.2"
       },
       "devDependencies": {
-        "@infrascan/sdk": "^0.2.2",
+        "@infrascan/sdk": "^0.3.0",
         "tsconfig": "^0.0.0"
       }
     },
     "packages/cli": {
       "name": "@infrascan/cli",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "3.428.0",
         "@infrascan/aws": "^0.3.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/sdk": "^0.2.2",
+        "@infrascan/sdk": "^0.3.0",
         "@rushstack/ts-command-line": "^4.15.2",
         "@smithy/shared-ini-file-loader": "^2.2.2",
         "minimatch": "^6.1.6"
@@ -18301,6 +18301,7 @@
       "devDependencies": {
         "@aws-sdk/types": "3.428.0",
         "@infrascan/shared-types": "^0.2.2",
+        "@smithy/types": "^2.4.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.3"
       }
@@ -18350,7 +18351,7 @@
     },
     "packages/sdk": {
       "name": "@infrascan/sdk",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "^3.428.0",
@@ -22425,7 +22426,7 @@
         "@infrascan/aws-s3-scanner": "^0.2.2",
         "@infrascan/aws-sns-scanner": "^0.2.2",
         "@infrascan/aws-sqs-scanner": "^0.2.2",
-        "@infrascan/sdk": "^0.2.2",
+        "@infrascan/sdk": "^0.3.0",
         "tsconfig": "^0.0.0"
       }
     },
@@ -23385,10 +23386,11 @@
         "@aws-sdk/types": "3.428.0",
         "@infrascan/aws": "^0.3.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/sdk": "^0.2.2",
+        "@infrascan/sdk": "^0.3.0",
         "@infrascan/shared-types": "^0.2.2",
         "@rushstack/ts-command-line": "^4.15.2",
         "@smithy/shared-ini-file-loader": "^2.2.2",
+        "@smithy/types": "^2.4.0",
         "minimatch": "^6.1.6",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.3"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@aws-sdk/types": "3.428.0",
     "@infrascan/shared-types": "^0.2.2",
+    "@smithy/types": "^2.4.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.3"
   }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { env } from "process";
+import { DEFAULT_PROFILE } from "@smithy/shared-ini-file-loader";
+import type { ParsedIniData } from "@smithy/types";
+
+export type ScanConfig = {
+  profile?: string;
+  roleToAssume?: string;
+  regions?: string[];
+}[];
+
+export function getConfig(path: string): ScanConfig {
+  const resolvedConfigPath = resolve(path);
+  return JSON.parse(readFileSync(resolvedConfigPath, "utf8"));
+}
+
+// Create a default config if file is given - scan the default region.
+export function getDefaultConfig(iniDefaultRegion?: ParsedIniData): ScanConfig {
+  console.log("No config file given. Deriving config from environment.");
+  const defaultRegion =
+    env.AWS_REGION ??
+    iniDefaultRegion?.[env.AWS_PROFILE ?? DEFAULT_PROFILE]?.region;
+  if (defaultRegion != null) {
+    console.log("Default region found: ", defaultRegion);
+    return [
+      {
+        regions: [defaultRegion],
+      },
+    ];
+  }
+  return [{}];
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -114,6 +114,7 @@ export default class Infrascan {
     const scanMetadata: ScanMetadata = {
       account: globalCaller.Account,
       regions: [],
+      defaultRegion,
     };
 
     const iamClient = new IAM({
@@ -224,8 +225,8 @@ export default class Infrascan {
     const globalServiceEntries = Object.values(this.globalScannerRegistry);
     const regionalServiceEntries = Object.values(this.regionalScannerRegistry);
 
-    for (const { account, regions } of scanMetadata) {
-      const context = { account, region: AWS_DEFAULT_REGION };
+    for (const { account, regions, defaultRegion } of scanMetadata) {
+      const context = { account, region: defaultRegion };
       const accountNode = buildAccountNode(account);
       addGraphElementToMap(graphNodes, accountNode);
 

--- a/packages/sdk/src/scan.ts
+++ b/packages/sdk/src/scan.ts
@@ -78,6 +78,10 @@ export type ScanMetadata = {
    * The regions scanned
    */
   regions: string[];
+  /**
+   * The region considered as default for the scan. Used to scrape state for global services.
+   */
+  defaultRegion: string;
 };
 
 export async function scanService(


### PR DESCRIPTION
Requiring a config file to run a first test is an unnecessary hurdle. This PR updates the CLI to source its environment variables from the default credentials provider chain. It also updates the SDK to include the default region in its scan metadata output. This removes a potential issue with the scan and graph being run in different contexts.