### PR TITLE
Fix: add support for overriding client retry strategy

### DIFF
--- a/.changeset/unlucky-readers-complain.md
+++ b/.changeset/unlucky-readers-complain.md
@@ -1,0 +1,21 @@
+---
+"@infrascan/aws-elastic-load-balancing-scanner": patch
+"@infrascan/aws-cloudwatch-logs-scanner": patch
+"@infrascan/aws-api-gateway-scanner": patch
+"@infrascan/aws-autoscaling-scanner": patch
+"@infrascan/aws-cloudfront-scanner": patch
+"@infrascan/aws-dynamodb-scanner": patch
+"@infrascan/shared-types": patch
+"@infrascan/aws-kinesis-scanner": patch
+"@infrascan/aws-route53-scanner": patch
+"@infrascan/aws-lambda-scanner": patch
+"@infrascan/aws-ec2-scanner": patch
+"@infrascan/aws-ecs-scanner": patch
+"@infrascan/aws-rds-scanner": patch
+"@infrascan/aws-sns-scanner": patch
+"@infrascan/aws-sqs-scanner": patch
+"@infrascan/aws-s3-scanner": patch
+"@infrascan/sdk": patch
+---
+
+Update to include support scanner level retry strategies

--- a/aws-scanners/api-gateway/src/generated/client.ts
+++ b/aws-scanners/api-gateway/src/generated/client.ts
@@ -1,10 +1,19 @@
 import { ApiGatewayV2Client } from "@aws-sdk/client-apigatewayv2";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): ApiGatewayV2Client {
-  return new ApiGatewayV2Client({ credentials, region: context.region });
+  return new ApiGatewayV2Client({
+    credentials,
+    region: context.region,
+    retryStrategy,
+  });
 }

--- a/aws-scanners/autoscaling/src/generated/client.ts
+++ b/aws-scanners/autoscaling/src/generated/client.ts
@@ -1,10 +1,19 @@
 import { AutoScalingClient } from "@aws-sdk/client-auto-scaling";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): AutoScalingClient {
-  return new AutoScalingClient({ credentials, region: context.region });
+  return new AutoScalingClient({
+    credentials,
+    region: context.region,
+    retryStrategy,
+  });
 }

--- a/aws-scanners/cloudfront/src/generated/client.ts
+++ b/aws-scanners/cloudfront/src/generated/client.ts
@@ -1,10 +1,19 @@
 import { CloudFrontClient } from "@aws-sdk/client-cloudfront";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): CloudFrontClient {
-  return new CloudFrontClient({ credentials, region: context.region });
+  return new CloudFrontClient({
+    credentials,
+    region: context.region,
+    retryStrategy,
+  });
 }

--- a/aws-scanners/cloudwatch-logs/src/generated/client.ts
+++ b/aws-scanners/cloudwatch-logs/src/generated/client.ts
@@ -1,10 +1,19 @@
 import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): CloudWatchLogsClient {
-  return new CloudWatchLogsClient({ credentials, region: context.region });
+  return new CloudWatchLogsClient({
+    credentials,
+    region: context.region,
+    retryStrategy,
+  });
 }

--- a/aws-scanners/codegen/src/index.ts
+++ b/aws-scanners/codegen/src/index.ts
@@ -31,12 +31,12 @@ function getServiceErrorType(scannerDefinition: BaseScannerDefinition): string {
  */
 function declareClientBuilder(scannerDefinition: BaseScannerDefinition, writer: CodeBlockWriter): CodeBlockWriter {
   return writer.writeLine(`import { ${getServiceClientClass(scannerDefinition)} } from "@aws-sdk/client-${scannerDefinition.service}";`)
-    .writeLine(`import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";`)
+    .writeLine(`import type { AwsCredentialIdentityProvider, RetryStrategy, RetryStrategyV2 } from "@aws-sdk/types";`)
     .writeLine(`import type { AwsContext } from "@infrascan/shared-types";`)
     .newLine()
-    .writeLine(`export function getClient(credentials: AwsCredentialIdentityProvider, context: AwsContext): ${getServiceClientClass(scannerDefinition)} {`)
+    .writeLine(`export function getClient(credentials: AwsCredentialIdentityProvider, context: AwsContext, retryStrategy?: RetryStrategy | RetryStrategyV2): ${getServiceClientClass(scannerDefinition)} {`)
     .tab()
-    .write(`return new ${getServiceClientClass(scannerDefinition)}({ credentials, region: context.region });`)
+    .write(`return new ${getServiceClientClass(scannerDefinition)}({ credentials, region: context.region, retryStrategy });`)
     .newLine()
     .writeLine('}\n');
 }

--- a/aws-scanners/dynamodb/src/generated/client.ts
+++ b/aws-scanners/dynamodb/src/generated/client.ts
@@ -1,10 +1,19 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): DynamoDBClient {
-  return new DynamoDBClient({ credentials, region: context.region });
+  return new DynamoDBClient({
+    credentials,
+    region: context.region,
+    retryStrategy,
+  });
 }

--- a/aws-scanners/ec2/src/generated/client.ts
+++ b/aws-scanners/ec2/src/generated/client.ts
@@ -1,10 +1,15 @@
 import { EC2Client } from "@aws-sdk/client-ec2";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): EC2Client {
-  return new EC2Client({ credentials, region: context.region });
+  return new EC2Client({ credentials, region: context.region, retryStrategy });
 }

--- a/aws-scanners/ecs/src/generated/client.ts
+++ b/aws-scanners/ecs/src/generated/client.ts
@@ -1,10 +1,15 @@
 import { ECSClient } from "@aws-sdk/client-ecs";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): ECSClient {
-  return new ECSClient({ credentials, region: context.region });
+  return new ECSClient({ credentials, region: context.region, retryStrategy });
 }

--- a/aws-scanners/elastic-load-balancing/src/generated/client.ts
+++ b/aws-scanners/elastic-load-balancing/src/generated/client.ts
@@ -1,13 +1,19 @@
 import { ElasticLoadBalancingV2Client } from "@aws-sdk/client-elastic-load-balancing-v2";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): ElasticLoadBalancingV2Client {
   return new ElasticLoadBalancingV2Client({
     credentials,
     region: context.region,
+    retryStrategy,
   });
 }

--- a/aws-scanners/kinesis/src/generated/client.ts
+++ b/aws-scanners/kinesis/src/generated/client.ts
@@ -1,10 +1,19 @@
 import { KinesisClient } from "@aws-sdk/client-kinesis";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): KinesisClient {
-  return new KinesisClient({ credentials, region: context.region });
+  return new KinesisClient({
+    credentials,
+    region: context.region,
+    retryStrategy,
+  });
 }

--- a/aws-scanners/lambda/src/generated/client.ts
+++ b/aws-scanners/lambda/src/generated/client.ts
@@ -1,10 +1,19 @@
 import { LambdaClient } from "@aws-sdk/client-lambda";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): LambdaClient {
-  return new LambdaClient({ credentials, region: context.region });
+  return new LambdaClient({
+    credentials,
+    region: context.region,
+    retryStrategy,
+  });
 }

--- a/aws-scanners/rds/src/generated/client.ts
+++ b/aws-scanners/rds/src/generated/client.ts
@@ -1,10 +1,15 @@
 import { RDSClient } from "@aws-sdk/client-rds";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): RDSClient {
-  return new RDSClient({ credentials, region: context.region });
+  return new RDSClient({ credentials, region: context.region, retryStrategy });
 }

--- a/aws-scanners/route53/src/generated/client.ts
+++ b/aws-scanners/route53/src/generated/client.ts
@@ -1,10 +1,19 @@
 import { Route53Client } from "@aws-sdk/client-route-53";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): Route53Client {
-  return new Route53Client({ credentials, region: context.region });
+  return new Route53Client({
+    credentials,
+    region: context.region,
+    retryStrategy,
+  });
 }

--- a/aws-scanners/s3/src/index.ts
+++ b/aws-scanners/s3/src/index.ts
@@ -6,7 +6,11 @@ import type {
   ServiceModule,
 } from "@infrascan/shared-types";
 
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 
 import {
   ListBuckets,
@@ -21,11 +25,13 @@ import { registerMiddleware } from "./middleware";
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): S3Client {
   const s3Client = new S3Client({
     credentials,
     region: context.region,
     followRegionRedirects: true,
+    retryStrategy,
   });
   registerMiddleware(s3Client);
   return s3Client;

--- a/aws-scanners/sns/src/generated/client.ts
+++ b/aws-scanners/sns/src/generated/client.ts
@@ -1,10 +1,15 @@
 import { SNSClient } from "@aws-sdk/client-sns";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): SNSClient {
-  return new SNSClient({ credentials, region: context.region });
+  return new SNSClient({ credentials, region: context.region, retryStrategy });
 }

--- a/aws-scanners/sqs/src/generated/client.ts
+++ b/aws-scanners/sqs/src/generated/client.ts
@@ -1,10 +1,15 @@
 import { SQSClient } from "@aws-sdk/client-sqs";
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type {
+  AwsCredentialIdentityProvider,
+  RetryStrategy,
+  RetryStrategyV2,
+} from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 
 export function getClient(
   credentials: AwsCredentialIdentityProvider,
   context: AwsContext,
+  retryStrategy?: RetryStrategy | RetryStrategyV2,
 ): SQSClient {
-  return new SQSClient({ credentials, region: context.region });
+  return new SQSClient({ credentials, region: context.region, retryStrategy });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18207,7 +18207,7 @@
     },
     "packages/fs-connector": {
       "name": "@infrascan/fs-connector",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "minimatch": "^9.0.3"
@@ -18221,7 +18221,7 @@
     },
     "packages/s3-connector": {
       "name": "@infrascan/s3-connector",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "3.428.0",
@@ -18247,6 +18247,7 @@
         "@aws-sdk/client-sts": "^3.428.0",
         "@aws-sdk/config-resolver": "3.369.0",
         "@infrascan/core": "^0.2.2",
+        "@smithy/util-retry": "^2.0.5",
         "jmespath": "^0.16.0",
         "minimatch": "^5.1.0"
       },
@@ -23337,7 +23338,7 @@
       "version": "file:packages/s3-connector",
       "requires": {
         "@aws-sdk/client-s3": "3.428.0",
-        "@aws-sdk/util-stream-node": "*",
+        "@aws-sdk/util-stream-node": "^3.374.0",
         "@infrascan/shared-types": "^0.2.2",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-custom": "*",
@@ -23357,6 +23358,7 @@
         "@aws-sdk/types": "3.428.0",
         "@infrascan/core": "^0.2.2",
         "@infrascan/shared-types": "*",
+        "@smithy/util-retry": "*",
         "@types/jmespath": "^0.15.0",
         "@types/minimatch": "^5.1.2",
         "@typescript-eslint/eslint-plugin": "^5.59.8",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -61,6 +61,7 @@
     "@aws-sdk/client-sts": "^3.428.0",
     "@aws-sdk/config-resolver": "3.369.0",
     "@infrascan/core": "^0.2.2",
+    "@smithy/util-retry": "^2.0.5",
     "jmespath": "^0.16.0",
     "minimatch": "^5.1.0"
   },

--- a/packages/sdk/src/scan.ts
+++ b/packages/sdk/src/scan.ts
@@ -1,6 +1,8 @@
 import { EC2 } from "@aws-sdk/client-ec2";
 import { GetCallerIdentityCommandOutput, STS } from "@aws-sdk/client-sts";
 import { IAM } from "@aws-sdk/client-iam";
+import { AdaptiveRetryStrategy } from "@smithy/util-retry";
+
 import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
 import type {
   AwsContext,
@@ -92,7 +94,11 @@ export async function scanService(
   iamClient: IAM,
   context: AwsContext,
 ): Promise<void> {
-  const serviceClient = serviceScanner.getClient(credentials, context);
+  const serviceClient = serviceScanner.getClient(
+    credentials,
+    context,
+    new AdaptiveRetryStrategy(async () => 5),
+  );
   for (const scannerFn of serviceScanner.getters) {
     await scannerFn(serviceClient, connector, context);
   }

--- a/packages/shared-types/src/api.ts
+++ b/packages/shared-types/src/api.ts
@@ -1,4 +1,4 @@
-import type { AwsCredentialIdentityProvider } from "@aws-sdk/types";
+import type { AwsCredentialIdentityProvider, RetryStrategy, RetryStrategyV2 } from "@aws-sdk/types";
 
 import type { GraphEdge, GraphNode } from "./graph";
 import type { BaseEdgeResolver } from "./config";
@@ -73,6 +73,7 @@ export interface Connector {
 type ClientBuilder<T, P extends Provider> = (
   credentials: AwsCredentialIdentityProvider,
   context: ProviderContextMap[P],
+  retryStrategy?: RetryStrategy | RetryStrategyV2
 ) => T;
 
 type GetterFn<T, P extends Provider> = (


### PR DESCRIPTION
Large scans were failing with throttling exceptions. Adding a retry strategy param should reduce this, and allow for fine tuning on a per service basis. 

SDK updated to default to AdaptiveStrategy during testing phase, future release will expose as a config option.