### PR TITLE
fix: add catch on iamRole scan

### DIFF
--- a/.changeset/brave-numbers-push.md
+++ b/.changeset/brave-numbers-push.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/sdk": patch
+---
+
+Catch error on iam role scanning

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
     },
     "aws-scanners/api-gateway": {
       "name": "@infrascan/aws-api-gateway-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-apigatewayv2": "3.428.0",
@@ -45,7 +45,7 @@
         "@aws-sdk/types": "3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -53,7 +53,7 @@
     },
     "aws-scanners/autoscaling": {
       "name": "@infrascan/aws-autoscaling-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-auto-scaling": "3.428.0",
@@ -63,7 +63,7 @@
         "@aws-sdk/credential-providers": "^3.427.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -71,7 +71,7 @@
     },
     "aws-scanners/cloudfront": {
       "name": "@infrascan/aws-cloudfront-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudfront": "3.428.0",
@@ -83,7 +83,7 @@
         "@aws-sdk/credential-providers": "^3.427.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -438,7 +438,7 @@
     },
     "aws-scanners/cloudwatch-logs": {
       "name": "@infrascan/aws-cloudwatch-logs-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.428.0",
@@ -448,7 +448,7 @@
         "@aws-sdk/credential-providers": "^3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -472,7 +472,7 @@
     },
     "aws-scanners/dynamodb": {
       "name": "@infrascan/aws-dynamodb-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.428.0",
@@ -480,14 +480,14 @@
       },
       "devDependencies": {
         "@infrascan/aws-codegen": "^0.1.0",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
       }
     },
     "aws-scanners/ec2": {
       "name": "@infrascan/aws-ec2-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "3.428.0",
@@ -495,7 +495,7 @@
       },
       "devDependencies": {
         "@infrascan/aws-codegen": "^0.1.0",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
       }
@@ -601,7 +601,7 @@
     },
     "aws-scanners/ecs": {
       "name": "@infrascan/aws-ecs-scanner",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ecs": "3.428.0",
@@ -611,7 +611,7 @@
         "@aws-sdk/credential-providers": "^3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.3",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -619,7 +619,7 @@
     },
     "aws-scanners/elastic-load-balancing": {
       "name": "@infrascan/aws-elastic-load-balancing-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-elastic-load-balancing-v2": "^3.421.0",
@@ -630,7 +630,7 @@
         "@aws-sdk/credential-providers": "^3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -862,7 +862,7 @@
     },
     "aws-scanners/kinesis": {
       "name": "@infrascan/aws-kinesis-scanner",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-kinesis": "^3.437.0",
@@ -872,7 +872,7 @@
         "@aws-sdk/credential-providers": "^3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -880,7 +880,7 @@
     },
     "aws-scanners/lambda": {
       "name": "@infrascan/aws-lambda-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-lambda": "3.428.0",
@@ -890,7 +890,7 @@
         "@aws-sdk/credential-providers": "^3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -898,7 +898,7 @@
     },
     "aws-scanners/rds": {
       "name": "@infrascan/aws-rds-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-rds": "^3.428.0",
@@ -906,7 +906,7 @@
       },
       "devDependencies": {
         "@infrascan/aws-codegen": "^0.1.0",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
       }
@@ -1127,7 +1127,7 @@
     },
     "aws-scanners/route53": {
       "name": "@infrascan/aws-route53-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-route-53": "3.428.0",
@@ -1140,14 +1140,14 @@
         "@aws-sdk/client-s3": "3.428.0",
         "@aws-sdk/client-sns": "3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
       }
     },
     "aws-scanners/s3": {
       "name": "@infrascan/aws-s3-scanner",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "3.428.0",
@@ -1157,7 +1157,7 @@
         "@aws-sdk/credential-providers": "^3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.3",
+        "@infrascan/shared-types": "^0.2.4",
         "@smithy/types": "^2.4.0",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
@@ -1166,7 +1166,7 @@
     },
     "aws-scanners/sns": {
       "name": "@infrascan/aws-sns-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-sns": "3.428.0",
@@ -1176,7 +1176,7 @@
         "@aws-sdk/credential-providers": "^3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -1184,7 +1184,7 @@
     },
     "aws-scanners/sqs": {
       "name": "@infrascan/aws-sqs-scanner",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-sqs": "3.428.0",
@@ -1194,7 +1194,7 @@
         "@aws-sdk/credential-providers": "^3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -18239,7 +18239,7 @@
     },
     "packages/sdk": {
       "name": "@infrascan/sdk",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "^3.428.0",
@@ -18276,7 +18276,7 @@
     },
     "packages/shared-types": {
       "name": "@infrascan/shared-types",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MPL-2.0",
       "devDependencies": {
         "@aws-sdk/types": "3.428.0",
@@ -22338,7 +22338,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -22352,7 +22352,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -22367,7 +22367,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "minimatch": "^9.0.3",
@@ -22660,7 +22660,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -22684,7 +22684,7 @@
         "@aws-sdk/client-dynamodb": "3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
       }
@@ -22695,7 +22695,7 @@
         "@aws-sdk/client-ec2": "3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
       },
@@ -22803,7 +22803,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.3",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -22818,7 +22818,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -23015,7 +23015,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -23029,7 +23029,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -23041,7 +23041,7 @@
         "@aws-sdk/client-rds": "^3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
       },
@@ -23229,7 +23229,7 @@
         "@aws-sdk/client-sns": "3.428.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "eslint-config-codegen": "^1.0.0",
         "minimatch": "^9.0.3",
         "tsconfig": "^0.0.0"
@@ -23243,7 +23243,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.3",
+        "@infrascan/shared-types": "^0.2.4",
         "@smithy/types": "^2.4.0",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
@@ -23258,7 +23258,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -23272,7 +23272,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/fs-connector": "^0.2.2",
-        "@infrascan/shared-types": "^0.2.2",
+        "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
@@ -23358,7 +23358,7 @@
         "@aws-sdk/types": "3.428.0",
         "@infrascan/core": "^0.2.2",
         "@infrascan/shared-types": "*",
-        "@smithy/util-retry": "*",
+        "@smithy/util-retry": "^2.0.5",
         "@types/jmespath": "^0.15.0",
         "@types/minimatch": "^5.1.2",
         "@typescript-eslint/eslint-plugin": "^5.59.8",

--- a/packages/sdk/src/scan.ts
+++ b/packages/sdk/src/scan.ts
@@ -106,7 +106,12 @@ export async function scanService(
     const iamRoles = await serviceScanner.getIamRoles(connector);
     await Promise.all(
       iamRoles.map(({ roleArn }) =>
-        scanIamRole(iamStorage, iamClient, roleArn),
+        scanIamRole(iamStorage, iamClient, roleArn).catch((err) => {
+          console.error("An error occurred while scanning role:",roleArn);
+          if(err instanceof Error) {
+            console.error(err.message);
+          }
+        }),
       ),
     );
   }


### PR DESCRIPTION
if an iam role scan errored, the scan would exit. Add log on error instead.