### PR TITLE
fix: account for single objects being returned by the IAM API

### DIFF
--- a/.changeset/big-jars-talk.md
+++ b/.changeset/big-jars-talk.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/sdk": patch
+---
+
+Account for non-list policy statements for IAM API.

--- a/packages/sdk/src/graph.ts
+++ b/packages/sdk/src/graph.ts
@@ -194,7 +194,8 @@ export async function generateEdgesForPolicyStatements(
 ): Promise<EdgeResource[]> {
   let resources: EdgeResource[] = [];
   for (const { label, statements } of policyStatements) {
-    for (const statement of statements) {
+    const mappedStatements = Array.isArray(statements) ? statements : [statements];
+    for (const statement of mappedStatements) {
       const { Resource } = statement;
       if (Array.isArray(Resource)) {
         for (const resourceGlobs of Resource) {


### PR DESCRIPTION
IAM role's policies can be single objects, which results in an error when graphing. Update iam edge generation to check if the policy is a list of statements, and wrap it if not.