### PR TITLE
Add validation on graph edges

### DIFF
--- a/.changeset/few-schools-act.md
+++ b/.changeset/few-schools-act.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/sdk": patch
+---
+
+Add validation to check that both source and destination nodes exist before inserting a graph edge

--- a/packages/sdk/src/graph.ts
+++ b/packages/sdk/src/graph.ts
@@ -83,6 +83,21 @@ export function addGraphElementToMap<T extends GraphElement>(
   }
 }
 
+export function addGraphEdgeToMap(
+  nodeMap: Record<string, GraphNode>,
+  edgeMap: Record<string, GraphEdge>,
+  element: GraphEdge,
+) {
+  const { source, target } = element.data;
+  const hasSource = nodeMap[source] != null;
+  const hasTarget = nodeMap[target] != null;
+  if (hasSource && hasTarget) {
+    addGraphElementToMap(edgeMap, element);
+  } else {
+    console.warn(`Found edge with missing source or target: ${source} -> ${target}`);
+  }
+}
+
 function getServiceFromArn(arn: string): string | undefined {
   const [, , service] = arn.split(":");
   return service;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -23,6 +23,7 @@ import {
   buildRegionNode,
   addGraphElementToMap,
   generateEdgesForRole,
+  addGraphEdgeToMap,
 } from "./graph";
 
 const AWS_DEFAULT_REGION = "us-east-1";
@@ -306,7 +307,7 @@ export default class Infrascan {
       if (scanner.getEdges != null) {
         console.log(`Getting Edges: ${scanner.service}`);
         const scannerEdges: GraphEdge[] = await scanner.getEdges(connector);
-        scannerEdges.forEach((edge) => addGraphElementToMap(graphEdges, edge));
+        scannerEdges.forEach((edge) => addGraphEdgeToMap(graphNodes, graphEdges, edge));
       }
     }
 
@@ -322,7 +323,9 @@ export default class Infrascan {
             executor,
             serviceNodeMap,
           );
-          roleEdges.forEach((edge) => addGraphElementToMap(graphEdges, edge));
+          roleEdges.forEach((edge) =>
+            addGraphEdgeToMap(graphNodes, graphEdges, edge),
+          );
         }
       }
     }


### PR DESCRIPTION
If a graph edge refers to a non-existent source or destination node, then the graph will fail to render. To avoid having to prune these edges out after graphing, the SDK validates that both source and destination nodes exist before inserting.