### PR TITLE
chore: add custom bash script to restrict preview builds

### DIFF
--- a/internal/scripts/ignore-preview-builds.sh
+++ b/internal/scripts/ignore-preview-builds.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
+
+if [[ "$VERCEL_GIT_COMMIT_REF" == "gh-pages" ]] ; then
+    # Cancel the build. gh-pages branch contains docs.
+    echo "🛑 - Build cancelled on gh-pages branch"
+    exit 0;
+
+else 
+    # Get root directory of the repo as an absolute path
+    GIT_ROOT_PATH=$(git rev-parse --show-toplevel)
+
+    if [[ -d "$GIT_ROOT_PATH/apps/render" ]]; then
+        echo "✅ - Running git diff in $GIT_ROOT_PATH/apps/render"
+        git diff HEAD^ HEAD --quiet "$GIT_ROOT_PATH"/apps/render
+    else
+        echo "🛑 - Build cancelled, no dir found at $GIT_ROOT_PATH/apps/render."
+        exit 0;
+    fi
+fi


### PR DESCRIPTION
Preview builds are being attempted on the gh-pages branch which will always fail (`apps/render` does not exist). This PR adds a bash script to skip builds on gh-pages, and to check if there are changes to the `apps/render` path on all other branches before continuing.