### PR TITLE
Feat: update codegen to use ejs templates

### DIFF
--- a/aws-scanners/api-gateway/package.json
+++ b/aws-scanners/api-gateway/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/api-gateway/src/generated/getters.ts
+++ b/aws-scanners/api-gateway/src/generated/getters.ts
@@ -1,20 +1,18 @@
 import {
   ApiGatewayV2Client,
-  GetApisCommand,
-  GetDomainNamesCommand,
   ApiGatewayV2ServiceException,
+  GetApisCommand,
+  GetApisCommandInput,
+  GetApisCommandOutput,
+  GetDomainNamesCommand,
+  GetDomainNamesCommandInput,
+  GetDomainNamesCommandOutput,
 } from "@aws-sdk/client-apigatewayv2";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  GetApisCommandInput,
-  GetApisCommandOutput,
-  GetDomainNamesCommandInput,
-  GetDomainNamesCommandOutput,
-} from "@aws-sdk/client-apigatewayv2";
 
 export async function GetApis(
   client: ApiGatewayV2Client,
@@ -51,7 +49,6 @@ export async function GetApis(
     state,
   );
 }
-
 export async function GetDomainNames(
   client: ApiGatewayV2Client,
   stateConnector: Connector,

--- a/aws-scanners/api-gateway/src/generated/graph.ts
+++ b/aws-scanners/api-gateway/src/generated/graph.ts
@@ -18,6 +18,7 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...GetApisNodes);
+
   return state.map((node) =>
     formatNode(node, "apigatewayv2", "ApiGateway", context, true),
   );

--- a/aws-scanners/api-gateway/tsconfig.json
+++ b/aws-scanners/api-gateway/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "tsconfig/base.json",
-  "exclude": ["codegen.ts", "config.ts", "test/*.test.ts"],
+  "exclude": [
+    "codegen.ts",
+    "config.ts",
+    "test/*.test.ts"
+  ],
   "compilerOptions": {
     "target": "ES2015",
-    "module": "Node16",
     "outDir": "./dist",
     "rootDir": "src",
     "baseUrl": "src"

--- a/aws-scanners/autoscaling/package.json
+++ b/aws-scanners/autoscaling/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/autoscaling/src/generated/getters.ts
+++ b/aws-scanners/autoscaling/src/generated/getters.ts
@@ -1,17 +1,15 @@
 import {
   AutoScalingClient,
-  DescribeAutoScalingGroupsCommand,
   AutoScalingServiceException,
+  DescribeAutoScalingGroupsCommand,
+  DescribeAutoScalingGroupsCommandInput,
+  DescribeAutoScalingGroupsCommandOutput,
 } from "@aws-sdk/client-auto-scaling";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  DescribeAutoScalingGroupsCommandInput,
-  DescribeAutoScalingGroupsCommandOutput,
-} from "@aws-sdk/client-auto-scaling";
 
 export async function DescribeAutoScalingGroups(
   client: AutoScalingClient,

--- a/aws-scanners/cloudfront/package.json
+++ b/aws-scanners/cloudfront/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/cloudfront/src/generated/getters.ts
+++ b/aws-scanners/cloudfront/src/generated/getters.ts
@@ -1,17 +1,15 @@
 import {
   CloudFrontClient,
-  ListDistributionsCommand,
   CloudFrontServiceException,
+  ListDistributionsCommand,
+  ListDistributionsCommandInput,
+  ListDistributionsCommandOutput,
 } from "@aws-sdk/client-cloudfront";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  ListDistributionsCommandInput,
-  ListDistributionsCommandOutput,
-} from "@aws-sdk/client-cloudfront";
 
 export async function ListDistributions(
   client: CloudFrontClient,

--- a/aws-scanners/cloudfront/src/generated/graph.ts
+++ b/aws-scanners/cloudfront/src/generated/graph.ts
@@ -18,6 +18,7 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...ListDistributionsNodes);
+
   return state.map((node) =>
     formatNode(node, "cloudfront", "CloudFront", context, false),
   );

--- a/aws-scanners/cloudwatch-logs/package.json
+++ b/aws-scanners/cloudwatch-logs/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/cloudwatch-logs/src/generated/getters.ts
+++ b/aws-scanners/cloudwatch-logs/src/generated/getters.ts
@@ -1,21 +1,19 @@
+import { resolveFunctionCallParameters } from "@infrascan/core";
 import {
   CloudWatchLogsClient,
-  DescribeLogGroupsCommand,
-  DescribeSubscriptionFiltersCommand,
   CloudWatchLogsServiceException,
+  DescribeLogGroupsCommand,
+  DescribeLogGroupsCommandInput,
+  DescribeLogGroupsCommandOutput,
+  DescribeSubscriptionFiltersCommand,
+  DescribeSubscriptionFiltersCommandInput,
+  DescribeSubscriptionFiltersCommandOutput,
 } from "@aws-sdk/client-cloudwatch-logs";
-import { resolveFunctionCallParameters } from "@infrascan/core";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  DescribeLogGroupsCommandInput,
-  DescribeLogGroupsCommandOutput,
-  DescribeSubscriptionFiltersCommandInput,
-  DescribeSubscriptionFiltersCommandOutput,
-} from "@aws-sdk/client-cloudwatch-logs";
 
 export async function DescribeLogGroups(
   client: CloudWatchLogsClient,
@@ -24,7 +22,7 @@ export async function DescribeLogGroups(
 ): Promise<void> {
   const state: GenericState[] = [];
   console.log("cloudwatch-logs DescribeLogGroups");
-  let pagingToken: string | undefined = undefined;
+  let pagingToken: string | undefined;
   do {
     const preparedParams: DescribeLogGroupsCommandInput = {};
     preparedParams.nextToken = pagingToken;
@@ -58,7 +56,6 @@ export async function DescribeLogGroups(
     state,
   );
 }
-
 export async function DescribeSubscriptionFilters(
   client: CloudWatchLogsClient,
   stateConnector: Connector,
@@ -80,7 +77,7 @@ export async function DescribeSubscriptionFilters(
     stateConnector,
   )) as DescribeSubscriptionFiltersCommandInput[];
   for (const parameters of parameterQueue) {
-    let pagingToken: string | undefined = undefined;
+    let pagingToken: string | undefined;
     do {
       const preparedParams: DescribeSubscriptionFiltersCommandInput =
         parameters;

--- a/aws-scanners/cloudwatch-logs/src/generated/graph.ts
+++ b/aws-scanners/cloudwatch-logs/src/generated/graph.ts
@@ -26,6 +26,7 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...DescribeSubscriptionFiltersNodes);
+
   return state.map((node) =>
     formatNode(node, "cloudwatch-logs", "CloudWatchLogs", context, true),
   );

--- a/aws-scanners/cloudwatch-logs/test/index.test.ts
+++ b/aws-scanners/cloudwatch-logs/test/index.test.ts
@@ -97,43 +97,43 @@ t.test(
   },
 );
 
-// t.test("No Log groups returned from DescribeLogGroups command", async () => {
-//   const testContext = {
-//     region: "us-east-1",
-//     account: "0".repeat(8),
-//   };
-//   const cloudwatchLogsClient = CloudwatchLogsScanner.getClient(
-//     fromProcess(),
-//     testContext,
-//   );
+t.test("No Log groups returned from DescribeLogGroups command", async () => {
+  const testContext = {
+    region: "us-east-1",
+    account: "0".repeat(8),
+  };
+  const cloudwatchLogsClient = CloudwatchLogsScanner.getClient(
+    fromProcess(),
+    testContext,
+  );
 
-//   const mockedCloudwatchLogsClient = mockClient(cloudwatchLogsClient);
+  const mockedCloudwatchLogsClient = mockClient(cloudwatchLogsClient);
 
-//   // Mock each of the functions used to pull state
-//   mockedCloudwatchLogsClient.on(DescribeLogGroupsCommand).resolves({
-//     logGroups: [],
-//   });
+  // Mock each of the functions used to pull state
+  mockedCloudwatchLogsClient.on(DescribeLogGroupsCommand).resolves({
+    logGroups: [],
+  });
 
-//   for (const scannerFn of CloudwatchLogsScanner.getters) {
-//     await scannerFn(cloudwatchLogsClient, connector, testContext);
-//   }
+  for (const scannerFn of CloudwatchLogsScanner.getters) {
+    await scannerFn(cloudwatchLogsClient, connector, testContext);
+  }
 
-//   const logGroupCallCount = mockedCloudwatchLogsClient.commandCalls(
-//     DescribeLogGroupsCommand,
-//   ).length;
-//   t.equal(logGroupCallCount, 1);
-//   const subscriptionCallCount = mockedCloudwatchLogsClient.commandCalls(
-//     DescribeSubscriptionFiltersCommand,
-//   ).length;
-//   t.equal(subscriptionCallCount, 0);
+  const logGroupCallCount = mockedCloudwatchLogsClient.commandCalls(
+    DescribeLogGroupsCommand,
+  ).length;
+  t.equal(logGroupCallCount, 1);
+  const subscriptionCallCount = mockedCloudwatchLogsClient.commandCalls(
+    DescribeSubscriptionFiltersCommand,
+  ).length;
+  t.equal(subscriptionCallCount, 0);
 
-//   if (CloudwatchLogsScanner.getNodes != null) {
-//     const nodes = await CloudwatchLogsScanner.getNodes(connector, testContext);
-//     t.equal(nodes.length, 0);
-//   }
+  if (CloudwatchLogsScanner.getNodes != null) {
+    const nodes = await CloudwatchLogsScanner.getNodes(connector, testContext);
+    t.equal(nodes.length, 0);
+  }
 
-//   if (CloudwatchLogsScanner.getEdges != null) {
-//     const edges = await CloudwatchLogsScanner.getEdges(connector);
-//     t.equal(edges.length, 0);
-//   }
-// });
+  if (CloudwatchLogsScanner.getEdges != null) {
+    const edges = await CloudwatchLogsScanner.getEdges(connector);
+    t.equal(edges.length, 0);
+  }
+});

--- a/aws-scanners/cloudwatch-logs/test/index.test.ts
+++ b/aws-scanners/cloudwatch-logs/test/index.test.ts
@@ -97,43 +97,43 @@ t.test(
   },
 );
 
-t.test("No Log groups returned from DescribeLogGroups command", async () => {
-  const testContext = {
-    region: "us-east-1",
-    account: "0".repeat(8),
-  };
-  const cloudwatchLogsClient = CloudwatchLogsScanner.getClient(
-    fromProcess(),
-    testContext,
-  );
+// t.test("No Log groups returned from DescribeLogGroups command", async () => {
+//   const testContext = {
+//     region: "us-east-1",
+//     account: "0".repeat(8),
+//   };
+//   const cloudwatchLogsClient = CloudwatchLogsScanner.getClient(
+//     fromProcess(),
+//     testContext,
+//   );
 
-  const mockedCloudwatchLogsClient = mockClient(cloudwatchLogsClient);
+//   const mockedCloudwatchLogsClient = mockClient(cloudwatchLogsClient);
 
-  // Mock each of the functions used to pull state
-  mockedCloudwatchLogsClient.on(DescribeLogGroupsCommand).resolves({
-    logGroups: [],
-  });
+//   // Mock each of the functions used to pull state
+//   mockedCloudwatchLogsClient.on(DescribeLogGroupsCommand).resolves({
+//     logGroups: [],
+//   });
 
-  for (const scannerFn of CloudwatchLogsScanner.getters) {
-    await scannerFn(cloudwatchLogsClient, connector, testContext);
-  }
+//   for (const scannerFn of CloudwatchLogsScanner.getters) {
+//     await scannerFn(cloudwatchLogsClient, connector, testContext);
+//   }
 
-  const logGroupCallCount = mockedCloudwatchLogsClient.commandCalls(
-    DescribeLogGroupsCommand,
-  ).length;
-  t.equal(logGroupCallCount, 1);
-  const subscriptionCallCount = mockedCloudwatchLogsClient.commandCalls(
-    DescribeSubscriptionFiltersCommand,
-  ).length;
-  t.equal(subscriptionCallCount, 0);
+//   const logGroupCallCount = mockedCloudwatchLogsClient.commandCalls(
+//     DescribeLogGroupsCommand,
+//   ).length;
+//   t.equal(logGroupCallCount, 1);
+//   const subscriptionCallCount = mockedCloudwatchLogsClient.commandCalls(
+//     DescribeSubscriptionFiltersCommand,
+//   ).length;
+//   t.equal(subscriptionCallCount, 0);
 
-  if (CloudwatchLogsScanner.getNodes != null) {
-    const nodes = await CloudwatchLogsScanner.getNodes(connector, testContext);
-    t.equal(nodes.length, 0);
-  }
+//   if (CloudwatchLogsScanner.getNodes != null) {
+//     const nodes = await CloudwatchLogsScanner.getNodes(connector, testContext);
+//     t.equal(nodes.length, 0);
+//   }
 
-  if (CloudwatchLogsScanner.getEdges != null) {
-    const edges = await CloudwatchLogsScanner.getEdges(connector);
-    t.equal(edges.length, 0);
-  }
-});
+//   if (CloudwatchLogsScanner.getEdges != null) {
+//     const edges = await CloudwatchLogsScanner.getEdges(connector);
+//     t.equal(edges.length, 0);
+//   }
+// });

--- a/aws-scanners/codegen/package.json
+++ b/aws-scanners/codegen/package.json
@@ -6,21 +6,22 @@
   "types": "./dist/index.d.ts",
   "private": true,
   "scripts": {
-    "build": "rm -rf dist ; tsc",
+    "build": "rm -rf dist ; tsc ; cp -r ./src/templates ./dist/templates",
     "clean": "rm -rf node_modules dist"
   },
   "keywords": [],
   "author": "Liam Farrelly <liam@l3f7.dev> (https://whoisli.am/)",
   "license": "MPL-2.0",
   "dependencies": {
-    "ts-morph": "^19.0.0",
+    "ejs": "^3.1.9",
     "typescript": "^5.1.3"
   },
   "devDependencies": {
     "@infrascan/shared-types": "^0.2.0",
+    "@types/ejs": "^3.1.5",
     "@types/node": "^20.3.1",
+    "eslint-config-custom": "*",
     "ts-node": "^10.9.1",
-    "tsconfig": "*",
-    "eslint-config-custom": "*"
+    "tsconfig": "*"
   }
 }

--- a/aws-scanners/codegen/src/index.ts
+++ b/aws-scanners/codegen/src/index.ts
@@ -1,333 +1,46 @@
-import { join } from "path";
-import { CodeBlockWriter, Project } from "ts-morph";
-
-import type { BaseScannerDefinition, BaseGetter } from "@infrascan/shared-types";
+import { renderFile } from 'ejs';
+import { existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { BaseScannerDefinition } from '@infrascan/shared-types';
 
 export type CodegenConfig = {
   basePath: string;
   overwrite: boolean;
 };
 
-function getFunctionNameForGetter(getter: BaseGetter): string {
-  return getter.id ?? getter.fn;
-}
-
-function getServiceClientClass(scannerDefinition: BaseScannerDefinition): string {
-  return `${scannerDefinition.clientKey}Client`;
-}
-
-function getServiceErrorType(scannerDefinition: BaseScannerDefinition): string {
-  return `${scannerDefinition.clientKey}ServiceException`;
-}
-
-/**
- * Declare function to create a client to be passed to the getters for this service
- * Example:
- * ```ts
- * function getClient(credentials: AwsCredentialIdentityProvider, region: string): LambdaClient {
- *  return new LambdaClient({ credentials, region });
- * }
- * ```
- */
-function declareClientBuilder(scannerDefinition: BaseScannerDefinition, writer: CodeBlockWriter): CodeBlockWriter {
-  return writer.writeLine(`import { ${getServiceClientClass(scannerDefinition)} } from "@aws-sdk/client-${scannerDefinition.service}";`)
-    .writeLine(`import type { AwsCredentialIdentityProvider, RetryStrategy, RetryStrategyV2 } from "@aws-sdk/types";`)
-    .writeLine(`import type { AwsContext } from "@infrascan/shared-types";`)
-    .newLine()
-    .writeLine(`export function getClient(credentials: AwsCredentialIdentityProvider, context: AwsContext, retryStrategy?: RetryStrategy | RetryStrategyV2): ${getServiceClientClass(scannerDefinition)} {`)
-    .tab()
-    .write(`return new ${getServiceClientClass(scannerDefinition)}({ credentials, region: context.region, retryStrategy });`)
-    .newLine()
-    .writeLine('}\n');
-}
-
-/**
- * Logs a suggested module export. This should be correct for most generated scanners, but will imports
- * will differ if any step is manually implemented.
- * @param scannerDefinition 
- * @returns {void}
- */
-function suggestModuleExport(scannerDefinition: BaseScannerDefinition) {  
-  const scannerGetterNames = scannerDefinition.getters.map(getFunctionNameForGetter);
-  const hasIamRoles = scannerDefinition.iamRoles != null;
-  let scannerGetterImports = scannerGetterNames.join(', ');
-  if(hasIamRoles) {
-    scannerGetterImports += ', getIamRoles';
+export default async function generateScanner(scannerDefinition: BaseScannerDefinition, config: CodegenConfig) {
+  const targetPath = join(config.basePath, 'generated/getters.ts');
+  if (existsSync(targetPath) && !config.overwrite) {
+    console.warn(targetPath, ' already exists. Pass overwrite: true in the codegen config to update it in place.');
+  } else {
+    const renderedScanner = await renderFile(join(__dirname, "./templates/service-scanner.ts.ejs"), scannerDefinition);
+    await writeFile(targetPath, renderedScanner);
   }
 
-  const hasNodes = (scannerDefinition.nodes?.length ?? 0) > 0;
-  const hasEdges = (scannerDefinition.edges?.length ?? 0) > 0;
-
-  const graphImports = [];
-  if(hasNodes) {
-    graphImports.push('getNodes');
+  if (!scannerDefinition.skipClientBuilder) {
+    const clientTargetPath = join(config.basePath, 'generated/client.ts');
+    if (existsSync(clientTargetPath) && !config.overwrite) {
+      console.warn(clientTargetPath, ' already exists. Pass overwrite: true in the codegen config to update it in place.');
+    } else {
+      const renderedClientBuilder = await renderFile(join(__dirname, "./templates/client-builder.ts.ejs"), scannerDefinition);
+      await writeFile(clientTargetPath, renderedClientBuilder);
+    }
   }
-  if(hasEdges) {
-    graphImports.push('getEdges');
+
+  if (scannerDefinition.edges != null || scannerDefinition.nodes != null) {
+    const graphTargetPath = join(config.basePath, "generated/graph.ts");
+    if (existsSync(graphTargetPath) && !config.overwrite) {
+      console.warn(graphTargetPath, ' already exists. Pass overwrite: true in the codegen config to update it in place.');
+    } else {
+      const renderedGraphSelector = await renderFile(join(__dirname, "./templates/graph-selector.ts.ejs"), scannerDefinition);
+      await writeFile(graphTargetPath, renderedGraphSelector);
+    }
   }
 
+  const suggestedExport = await renderFile(join(__dirname, "./templates/module-export.ts.ejs"), scannerDefinition);
   console.log("The expected export for this scanner is below. It should, at a minimum, serve as a strong starting point.")
   console.log("-----BEGIN EXPECTED EXPORT-----");
-  console.log(`import { ${getServiceClientClass(scannerDefinition)} } from "@aws-sdk/client-${scannerDefinition.service}"; 
-${scannerDefinition.skipClientBuilder ? '' : 'import { getClient } from "./generated/client";'}
-import { ${scannerGetterImports} } from "./generated/getters";
-${graphImports.length ? `import { ${graphImports.join(',')} } from "./generated/graph";` : ""}
-import type { ServiceModule } from "@infrascan/shared-types";
-
-const ${scannerDefinition.clientKey}Scanner: ServiceModule<${getServiceClientClass(scannerDefinition)}, "aws"> = {
-  provider: "${scannerDefinition.provider ?? "aws"}",
-  service: "${scannerDefinition.service}",
-  key: "${scannerDefinition.key}",
-  getClient,
-  ${scannerDefinition.arnLabel ? `arnLabel: "${scannerDefinition.arnLabel}",` : ""}
-  callPerRegion: ${scannerDefinition.callPerRegion},
-  getters: [${scannerGetterImports}],
-  ${hasNodes ? `getNodes,` : ""}
-  ${hasEdges ? `getEdges,` : ""}
-  ${hasIamRoles ? "getIamRoles," : "" }
-};
-
-export default ${scannerDefinition.clientKey}Scanner;`);
-console.log("-----END EXPECTED EXPORT-----");
-}
-
-type Commands = {
-  command: string;
-  input: string;
-  output: string;
-};
-
-function getCommandTypesForServiceGetter(getter: BaseGetter): Commands {
-  return {
-    command: `${getter.fn}Command`,
-    input: `${getter.fn}CommandInput`,
-    output: `${getter.fn}CommandOutput`
-  };
-}
-
-/**
- * Handles logic to scrape nodes and edges from state. Converts config selectors into explicit queries via the state connector to load and format the data.
- * @param scannerDefinition
- * @param sourceFile 
- * @returns Updated code block writer
- */
-function declareGraphSelector(scannerDefinition: BaseScannerDefinition, sourceFile: CodeBlockWriter): CodeBlockWriter {
-  const nodes = scannerDefinition.nodes ?? [];
-  const hasNodes = nodes.length > 0;
-
-  const edges = scannerDefinition.edges ?? [];
-  const hasEdges = edges.length > 0;
-
-  if(!hasEdges && !hasNodes) {
-    return sourceFile;
-  }
-
-  const coreImports = [];
-  if(hasNodes) {
-    coreImports.push("evaluateSelector");
-    coreImports.push("formatNode");
-  } 
-  if(hasEdges) {
-    coreImports.push("evaluateSelectorGlobally");
-    coreImports.push("filterState");
-    coreImports.push("formatEdge");
-  }
-
-  const typeImports = [];
-  if(hasNodes) {
-    typeImports.push("SelectedNode");
-    typeImports.push("GraphNode");
-  }
-  if(hasEdges) {
-    typeImports.push("GraphEdge");
-    typeImports.push("EdgeTarget");
-  }
-
-  let lastFnLabel: string | null;
-  return sourceFile.writeLine(`import { ${coreImports.join(', ')} } from "@infrascan/core";`)
-    .writeLine(`import type { Connector, AwsContext, ${typeImports.join(', ')} } from "@infrascan/shared-types";`)
-    .newLine()
-    .conditionalWriteLine(hasNodes, "export async function getNodes(stateConnector: Connector, context: AwsContext): Promise<GraphNode[]> {")
-    .conditionalWriteLine(hasNodes, "\tconst state: SelectedNode[] = [];")
-    .conditionalWrite(hasNodes, () => nodes.map((selector,idx) => {
-      const fnLabel = selector.split('|')[1];
-      let nodesVariable = `${fnLabel}Nodes`;
-      if(fnLabel == lastFnLabel) {
-        nodesVariable += idx;
-      }
-      const evaluateNodes = `\tconst ${nodesVariable} = await evaluateSelector(context.account, context.region, '${selector}', stateConnector);`;
-      const extendState = `\tstate.push(...${nodesVariable});`;
-      if(fnLabel != lastFnLabel) {
-        lastFnLabel = fnLabel;
-      }
-      return evaluateNodes + "\n" + extendState;
-    }).join('\n'))
-    .conditionalWriteLine(hasNodes, `\treturn state.map((node) => formatNode(node, "${scannerDefinition.service}", "${scannerDefinition.key}", context, ${scannerDefinition.callPerRegion}));`)
-    .conditionalWriteLine(hasNodes, '}')
-    .conditionalNewLine(hasNodes)
-    .conditionalWriteLine(hasEdges, "export async function getEdges(stateConnector: Connector): Promise<GraphEdge[]> {")
-    .conditionalWriteLine(hasEdges, "\tconst edges: GraphEdge[] = [];")
-    .conditionalWrite(hasEdges, () => edges.map(({ state, from, to }, idx) => {
-      const fnLabel = state.split('|')[1];
-      const edgesState = `\tconst ${fnLabel}State${idx+1} = await evaluateSelectorGlobally("${state}", stateConnector);`;
-      const evaluateEdges = `\tconst ${fnLabel}Edges${idx+1} = ${fnLabel}State${idx+1}.flatMap((state: any) => {
-    const source = filterState(state, "${from}");
-    const target: EdgeTarget | EdgeTarget[] | null = filterState(state, "${to}");
-    if(!target || !source) {
-      return [];
-    }
-    // Handle case of one to many edges
-    if (Array.isArray(target)) {
-      return target.map((edgeTarget) => formatEdge(source, edgeTarget));
-    } else {
-      return formatEdge(source, target);
-    }
-  });`
-      const extendEdgeState = `\tedges.push(...${fnLabel}Edges${idx+1});`
-      return edgesState + "\n" + evaluateEdges + "\n" + extendEdgeState;
-    }).join('\n'))
-    .conditionalWriteLine(hasEdges, "\treturn edges;")
-    .conditionalWriteLine(hasEdges, "}");
-}
-
-/**
- * Returns references to IAM Role Arns and the ID of the Node that will take them. This roles are considered within the global context based on AWS' tenancy model.
- * @param scannerDefinition 
- * @param sourceFile 
- * @returns Updated code block writer
- */
-function declareIamRoleGetter(scannerDefinition: BaseScannerDefinition, sourceFile: CodeBlockWriter): CodeBlockWriter {
-  const iamRoles = scannerDefinition.iamRoles ?? [];
-  if(iamRoles.length === 0) {
-    return sourceFile;
-  }
-
-  const iamRoleGetterFunc = sourceFile.writeLine(`export async function getIamRoles(stateConnector: Connector): Promise<EntityRoleData[]> {`)
-    .writeLine(`\tlet state: EntityRoleData[] = [];`);
-
-  let lastStateSelector: string | null;
-  iamRoles.forEach((selector, idx) => {
-    const [_, func] = selector.split('|');
-    let iamRoleState = `${func}RoleState`;
-    if(lastStateSelector == iamRoleState) {
-      iamRoleState += idx;
-    }
-    iamRoleGetterFunc
-      .writeLine(`\tconst ${iamRoleState} = (await evaluateSelectorGlobally("${selector}", stateConnector)) as EntityRoleData[];`)
-      .writeLine(`\tstate = state.concat(${iamRoleState});`);
-    if(lastStateSelector != iamRoleState) {
-      lastStateSelector = iamRoleState;
-    }
-  });
-  
-  return iamRoleGetterFunc
-    .writeLine('\treturn state;')
-    .writeLine('}')
-    .newLine();
-}
-
-function declareGetter(scannerDefinition: BaseScannerDefinition, getter: BaseGetter, sourceFile: CodeBlockWriter): CodeBlockWriter {
-  const commandTypes = getCommandTypesForServiceGetter(getter);
-
-  const hasParameters = getter.parameters != null;
-  const hasPaginationTokens = getter.paginationToken != null;
-
-  return sourceFile.write(`export async function ${getFunctionNameForGetter(getter)}(client: ${getServiceClientClass(scannerDefinition)}, stateConnector: Connector, context: AwsContext): Promise<void> {`)
-    .writeLine(`const state: GenericState[] = [];`)
-    // TODO: handle verbose logging correctly in generated code
-    .writeLine(`console.log("${scannerDefinition.service} ${getFunctionNameForGetter(getter)}");`)
-    .conditionalWriteLine(hasParameters, `const resolvers = ${JSON.stringify(getter.parameters)};`)
-    .conditionalWriteLine(hasParameters, `const parameterQueue = await resolveFunctionCallParameters(context.account, context.region, resolvers, stateConnector) as ${commandTypes.input}[];`)
-    .conditionalWriteLine(hasParameters, `for(const parameters of parameterQueue) {`)
-    .conditionalWriteLine(hasPaginationTokens, `\tlet pagingToken: string | undefined = undefined;`)
-    .conditionalWriteLine(hasPaginationTokens, "\tdo {")
-    .conditionalWriteLine(!hasParameters,`\t\tconst preparedParams: ${commandTypes.input} = {};`)
-    .conditionalWriteLine(hasParameters, `\t\tconst preparedParams: ${commandTypes.input} = parameters;`)
-    .conditionalWriteLine(hasPaginationTokens, `\t\tpreparedParams["${getter.paginationToken?.request}"] = pagingToken;`)
-    .writeLine("\t\ttry {")
-    .writeLine(`\t\t\tconst cmd = new ${commandTypes.command}(preparedParams);`)
-    .writeLine(`\t\t\tconst result: ${commandTypes.output} = await client.send(cmd);`)
-    .writeLine(`\t\t\tstate.push({ _metadata: { account: context.account, region: context.region }, _parameters: preparedParams, _result: result })`)
-    .conditionalWriteLine(hasPaginationTokens, `\t\t\tpagingToken = result["${getter.paginationToken?.response}"];`)
-    .writeLine("\t\t} catch(err: unknown) {")
-      // TODO: proper error handling
-    .writeLine(`\t\t\tif(err instanceof ${getServiceErrorType(scannerDefinition)}) {`)
-    .writeLine("\t\t\t\tif(err?.$retryable) {")
-    .writeLine(`\t\t\t\t\tconsole.log("Encountered retryable error", err);`)
-    .writeLine(`\t\t\t\t} else {`)
-    .writeLine(`\t\t\t\t\tconsole.log("Encountered unretryable error", err);`)
-    .writeLine("\t\t\t\t}")
-    .writeLine("\t\t\t} else {")
-    .writeLine('\t\t\t\tconsole.log("Encountered unexpected error", err);')
-    .writeLine("\t\t\t}")
-    .conditionalWriteLine(hasPaginationTokens, "\t\tpagingToken = undefined;")
-    .writeLine("\t\t}")
-    .conditionalWriteLine(hasPaginationTokens, `\t} while(pagingToken != null);`)
-    // close outer for loop for parameterised scanners
-    .conditionalWriteLine(hasParameters, "\t\t}")
-    .writeLine(`\tawait stateConnector.onServiceScanCompleteCallback(context.account, context.region, "${scannerDefinition.clientKey}", "${getFunctionNameForGetter(getter)}", state);`)
-    .writeLine("}")
-    .newLine();
-}
-
-export default async function generateScanner(scannerDefinition: BaseScannerDefinition, config: CodegenConfig) {
-  const project = new Project();
-
-  const getters = project.createSourceFile(
-    join(config.basePath, "generated/getters.ts"),
-    (writer) => {
-      const hasParameterisedGetter = scannerDefinition.getters.some((getter) => getter.parameters != null);
-      const hasRoles = (scannerDefinition.iamRoles ?? []).length > 0;
-      
-      // Get all of the `Command` types required for this scanner
-      const getterImports = scannerDefinition.getters.map(getCommandTypesForServiceGetter);
-      // Then split between `XXXCommand` (used as a Class) and `XXXCommandInput/Output` types (used as types)
-      const getterCommands = getterImports.map((types) => types.command).join(', ');
-      const getterCommandTypes = getterImports.map((types) => `${types.input}, ${types.output}`).join(', ');
-
-      const coreImports = [];
-      const typeImports = ["Connector", "GenericState", "AwsContext"];
-      if(hasRoles) {
-        typeImports.push("EntityRoleData");
-        coreImports.push('evaluateSelectorGlobally');
-      }
-      if(hasParameterisedGetter) {
-        coreImports.push('resolveFunctionCallParameters');
-      }
-
-
-      const sourceWriter = writer.writeLine(`import { ${getServiceClientClass(scannerDefinition)}, ${getterCommands}, ${getServiceErrorType(scannerDefinition)} } from "@aws-sdk/client-${scannerDefinition.service}";`)
-        .conditionalWriteLine(coreImports.length > 0, `import { ${coreImports.join(', ')} } from "@infrascan/core";`)
-        .writeLine(`import type { ${typeImports.join(', ')} } from "@infrascan/shared-types";`)
-        .writeLine(`import type { ${getterCommandTypes} } from "@aws-sdk/client-${scannerDefinition.service}";`)
-        .newLine();
-      scannerDefinition.getters.forEach((getter) => declareGetter(scannerDefinition, getter, sourceWriter));
-      if(hasRoles){
-        declareIamRoleGetter(scannerDefinition, sourceWriter);
-      }
-    },
-    { overwrite: config.overwrite },
-  );
-
-  await getters.save();
-
-  if(!scannerDefinition.skipClientBuilder) {
-    const clientBuilder = project.createSourceFile(
-      join(config.basePath, 'generated/client.ts'),
-      (writer) => declareClientBuilder(scannerDefinition, writer),
-      { overwrite: config.overwrite }
-    );
-    await clientBuilder.save();
-  }
-
-  if(scannerDefinition.edges != null || scannerDefinition.nodes != null) {
-    const nodesSelectors = project.createSourceFile(
-      join(config.basePath, 'generated/graph.ts'),
-      (writer) => declareGraphSelector(scannerDefinition, writer),
-      { overwrite: config.overwrite }
-    );
-    await nodesSelectors.save();
-  }
-
-  suggestModuleExport(scannerDefinition);
+  console.log(suggestedExport);
+  console.log("-----END EXPECTED EXPORT-----");
 }

--- a/aws-scanners/codegen/src/index.ts
+++ b/aws-scanners/codegen/src/index.ts
@@ -1,6 +1,6 @@
 import { renderFile } from 'ejs';
 import { existsSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
+import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { BaseScannerDefinition } from '@infrascan/shared-types';
 
@@ -10,6 +10,11 @@ export type CodegenConfig = {
 };
 
 export default async function generateScanner(scannerDefinition: BaseScannerDefinition, config: CodegenConfig) {
+  const generatedFilesBasePath = join(config.basePath, 'generated');
+  if (!existsSync(generatedFilesBasePath)) {
+    await mkdir(generatedFilesBasePath);
+  }
+
   const targetPath = join(config.basePath, 'generated/getters.ts');
   if (existsSync(targetPath) && !config.overwrite) {
     console.warn(targetPath, ' already exists. Pass overwrite: true in the codegen config to update it in place.');

--- a/aws-scanners/codegen/src/templates/client-builder.ts.ejs
+++ b/aws-scanners/codegen/src/templates/client-builder.ts.ejs
@@ -1,0 +1,12 @@
+<%_ const serviceClientClass=`${clientKey}Client`; -%>
+import { <%= serviceClientClass %> } from "@aws-sdk/client-<%=service%>";
+import type { AwsCredentialIdentityProvider, RetryStrategy, RetryStrategyV2 } from "@aws-sdk/types";
+import type { AwsContext } from "@infrascan/shared-types";
+
+export function getClient(
+    credentials: AwsCredentialIdentityProvider, 
+    context: AwsContext, 
+    retryStrategy?: RetryStrategy | RetryStrategyV2
+): <%= serviceClientClass %> {
+    return new <%= serviceClientClass %>({ credentials, region: context.region, retryStrategy });
+}

--- a/aws-scanners/codegen/src/templates/graph-selector.ts.ejs
+++ b/aws-scanners/codegen/src/templates/graph-selector.ts.ejs
@@ -1,0 +1,75 @@
+<%_ const hasNodes = locals.nodes && locals.nodes.length > 0; -%>
+<%_ const hasEdges = locals.edges && locals.edges.length > 0; -%>
+import { 
+<%_ if(hasNodes) { -%>
+    evaluateSelector, 
+    formatNode,
+<%_ } -%>
+<%_ if(hasEdges) { -%>
+    evaluateSelectorGlobally, 
+    filterState, 
+    formatEdge
+<%_ } -%>
+} from "@infrascan/core";
+import type { 
+    Connector,
+    AwsContext,
+<%_ if(hasNodes) { -%>
+    SelectedNode, 
+    GraphNode,
+<%_ } -%>
+<%_ if(hasEdges) { -%>
+    GraphEdge, 
+    EdgeTarget
+<%_ } -%>
+} from "@infrascan/shared-types";
+
+<%_ if(hasNodes){ -%>
+export async function getNodes(stateConnector: Connector, context: AwsContext): Promise<GraphNode[]> {
+    const state: SelectedNode[] = [];
+    <%_ let lastVariable = null; -%>
+    <%_ locals.nodes.forEach((nodeSelector, idx) => { -%>
+    <%_ const fnLabel = nodeSelector.split('|')[1]; -%>
+    <%_ let nodesVariable = `${fnLabel}Nodes`; -%>
+    <%_ if(nodesVariable === lastVariable) { -%>
+    <%_      nodesVariable += idx; -%>
+    <%_ } -%>
+    const <%= nodesVariable %> = await evaluateSelector(context.account, context.region, '<%- nodeSelector %>', stateConnector);
+    state.push(...<%= nodesVariable %>);
+    <%_ lastVariable = nodesVariable; -%>
+    <% }); %>
+    return state.map((node) => formatNode(
+        node, 
+        "<%= service %>", 
+        "<%= key %>", 
+        context, 
+        <%= callPerRegion %>
+    ));
+}
+<%_ } -%>
+<% if(hasEdges){ %>
+export async function getEdges(stateConnector: Connector): Promise<GraphEdge[]> {
+    const edges: GraphEdge[] = [];
+    <%_ locals.edges.forEach(({ state, to, from }, idx) => { -%>
+    <%_ const fnLabel = state.split('|')[1]; -%>
+    <%_ const stateVariable = `${fnLabel}State${idx+1}`; -%>
+    <%_ const edgesVariable = `${fnLabel}Edges${idx+1}`; -%>
+    const <%= stateVariable %> = await evaluateSelectorGlobally("<%- state %>", stateConnector);
+    const <%= edgesVariable %> = <%= stateVariable %>.flatMap((state: any) => {
+        const source = filterState(state, "<%- from %>");
+        const target: EdgeTarget | EdgeTarget[] | null = filterState(state, "<%- to %>");
+        if(!target || !source) {
+            return [];
+        }
+        // Handle case of one to many edges
+        if (Array.isArray(target)) {
+            return target.map((edgeTarget) => formatEdge(source, edgeTarget));
+        } else {
+            return formatEdge(source, target);
+        }
+    });
+    edges.push(...<%= edgesVariable %>);
+    <%_ }); -%>
+    return edges;
+}
+<% } %>

--- a/aws-scanners/codegen/src/templates/iam-role-scanner.ts.ejs
+++ b/aws-scanners/codegen/src/templates/iam-role-scanner.ts.ejs
@@ -1,0 +1,20 @@
+export async function getIamRoles(stateConnector: Connector): Promise<EntityRoleData[]> {
+    const state: EntityRoleData[] = [];
+    <%_ let lastStateVariable = null; -%>
+    <%_ iamRoles.forEach((selector, idx) => { -%>
+    <%_ const [_, func] = selector.split('|'); -%>
+    <%_ let iamRoleStateVariable = `${func}RoleState`; -%>
+    <%_ if(lastStateVariable == iamRoleStateVariable) { -%>
+        <%_ iamRoleStateVariable += idx; -%>
+    <%_ } -%>
+    const <%=iamRoleStateVariable%> = (await evaluateSelectorGlobally(
+        "<%=selector%>", 
+        stateConnector
+    )) as EntityRoleData[];
+    state.push(...<%=iamRoleStateVariable%>);
+    <%_ if(lastStateVariable != iamRoleStateVariable) { -%>
+        <%_ lastStateVariable = iamRoleStateVariable; -%>
+    <%_ } -%>
+    <%_ }); -%>
+    return state;
+}

--- a/aws-scanners/codegen/src/templates/module-export.ts.ejs
+++ b/aws-scanners/codegen/src/templates/module-export.ts.ejs
@@ -1,0 +1,42 @@
+<%_ const serviceClientClass = `${clientKey}Client`; -%>
+import { <%=serviceClientClass%> } from "@aws-sdk/client-<%=service%>"; 
+<%_ if(!locals.skipClientBuilder) { -%>
+import { getClient } from "./generated/client";
+<%_ } -%>
+import {
+    <%_ const getterImports = getters.map(({ id, fn }) => id ?? fn); -%>
+    <%_ if(locals.iamRoles != null) { -%>
+    <%_    getterImports.push('getIamRoles'); -%>
+    <%_ } -%>
+    <%=getterImports.join(', ')%>
+} from "./generated/getters";
+import { 
+    <%_ if(locals.nodes != null) { -%> getNodes,<%}-%>
+    <%_ if(locals.edges != null) { -%> getEdges,<%}-%>
+} from "./generated/graph";
+import type { ServiceModule } from "@infrascan/shared-types";
+
+const <%=clientKey%>Scanner: ServiceModule<<%=serviceClientClass%>, "aws"> = {
+  provider: "<%= provider %>",
+  service: "<%=service%>",
+  key: "<%=key%>",
+  <%_ if(!locals.skipClientBuilder) { -%>
+  getClient,
+  <%_ } -%>
+  <%_ if(locals.arnLabel != null) { -%>
+  arnLabel: "<%=locals.arnLabel%>",
+  <%_ } -%>
+  callPerRegion: <%=callPerRegion%>,
+  getters: [<%=getterImports%>],
+  <%_ if(locals.nodes != null) { -%>
+  getNodes,  
+  <%_ } -%>
+  <%_ if(locals.edges != null) { -%>
+  getEdges,  
+  <%_ } -%>
+  <%_ if(locals.iamRoles) { -%>
+  getIamRoles,
+  <%_ } -%>
+};
+
+export default <%=clientKey%>Scanner;

--- a/aws-scanners/codegen/src/templates/paginated-parameterised-selector.ts.ejs
+++ b/aws-scanners/codegen/src/templates/paginated-parameterised-selector.ts.ejs
@@ -1,0 +1,39 @@
+export async function <%= getter.id ?? getter.fn %>(
+    client: <%= serviceClientClass %>, 
+    stateConnector: Connector, 
+    context: AwsContext
+): Promise<void> {
+    const state: GenericState[] = [];
+    console.log("<%= service %> <%= getter.id ?? getter.fn %>");
+    const resolvers = <%- JSON.stringify(getter.parameters) %>;
+    const parameterQueue = await resolveFunctionCallParameters(context.account, context.region, resolvers, stateConnector) as <%= getter.id ?? getter.fn %>CommandInput[];
+    for(const parameters of parameterQueue) {
+        let pagingToken: string | undefined;
+        do {
+            const preparedParams: <%= getter.id ?? getter.fn %>CommandInput = parameters;
+            preparedParams["<%= getter.paginationToken.request %>"] = pagingToken;
+            try {
+                const cmd = new <%= getter.fn %>Command(preparedParams);
+                const result: <%= getter.fn %>CommandOutput = await client.send(cmd);
+                state.push({ _metadata: 
+                    { account: context.account, region: context.region }, 
+                    _parameters: preparedParams, 
+                    _result: result 
+                });
+                pagingToken = result["<%= getter.paginationToken.response %>"];
+            } catch(err: unknown) {
+                if(err instanceof <%= serviceErrorType %>) {
+                    if(err?.$retryable) {
+                        console.log("Encountered retryable error", err);
+                    } else {
+                        console.log("Encountered unretryable error", err);
+                    }
+                } else {
+                    console.log("Encountered unexpected error", err);
+                }
+                pagingToken = undefined;
+            }
+        }while(pagingToken != null);
+    }
+    await stateConnector.onServiceScanCompleteCallback(context.account, context.region, "<%= clientKey %>", "<%= getter.id ?? getter.fn %>", state);
+}

--- a/aws-scanners/codegen/src/templates/paginated-selector.ts.ejs
+++ b/aws-scanners/codegen/src/templates/paginated-selector.ts.ejs
@@ -1,0 +1,35 @@
+export async function <%= getter.id ?? getter.fn %>(
+    client: <%= serviceClientClass %>, 
+    stateConnector: Connector, 
+    context: AwsContext
+): Promise<void> {
+    const state: GenericState[] = [];
+    console.log("<%= service %> <%= getter.id ?? getter.fn %>");
+    let pagingToken: string | undefined;
+    do {
+        const preparedParams: <%= getter.fn %>CommandInput = {};
+        preparedParams["<%= getter.paginationToken.request %>"] = pagingToken;
+        try {
+            const cmd = new <%= getter.fn %>Command(preparedParams);
+            const result: <%= getter.fn %>CommandOutput = await client.send(cmd);
+            state.push({ _metadata: 
+                { account: context.account, region: context.region }, 
+                _parameters: preparedParams, 
+                _result: result 
+            });
+            pagingToken = result["<%= getter.paginationToken.response %>"];
+        } catch(err: unknown) {
+            if(err instanceof <%= serviceErrorType %>) {
+                if(err?.$retryable) {
+                    console.log("Encountered retryable error", err);
+                } else {
+                    console.log("Encountered unretryable error", err);
+                }
+            } else {
+                console.log("Encountered unexpected error", err);
+            }
+            pagingToken = undefined;
+        }
+    } while(pagingToken != null);
+    await stateConnector.onServiceScanCompleteCallback(context.account, context.region, "<%= clientKey %>", "<%= getter.id ?? getter.fn %>", state);
+}

--- a/aws-scanners/codegen/src/templates/service-scanner.ts.ejs
+++ b/aws-scanners/codegen/src/templates/service-scanner.ts.ejs
@@ -1,0 +1,39 @@
+<%# Declare helper types before implementing template %>
+<%_ const hasRoles = locals.iamRoles && locals.iamRoles?.length > 0; -%>
+<%_ const hasParameterisedGetter = getters && getters.some((getter) => getter.parameters != null); -%>
+<%_ const serviceClientClass=`${clientKey}Client`; -%>
+<%_ const serviceErrorType=`${clientKey}ServiceException`; -%>
+<%# Begin template %>
+<%_ if(hasParameterisedGetter && hasRoles) { -%>
+import { evaluateSelectorGlobally, resolveFunctionCallParameters } from "@infrascan/core";
+<%_ } else if (hasParameterisedGetter) { -%>
+import { resolveFunctionCallParameters } from "@infrascan/core";
+<%_ } -%>
+import { <%= serviceClientClass %>, <%= serviceErrorType %> } from "@aws-sdk/client-<%=service%>";
+<%_ getters.forEach(({ fn }) => { -%>
+import { <%=fn%>Command,<%=fn%>CommandInput,<%=fn%>CommandOutput } from "@aws-sdk/client-<%=service%>";
+<%_ }); -%>
+import type { 
+    Connector, 
+    GenericState, 
+    AwsContext,
+    <%_ if(hasRoles) { -%>
+    EntityRoleData,
+    <%_ } -%>
+} from "@infrascan/shared-types";
+
+<% getters.forEach((getter) => { -%>
+<%_ if(getter.paginationToken != null && getter.parameters != null) { -%>
+<%- include('paginated-parameterised-selector.ts.ejs', { getter, serviceErrorType, service, serviceClientClass }); %>
+<%_ } else if (getter.paginationToken != null && getter.parameters == null) { -%>
+<%- include('paginated-selector.ts.ejs', { getter, serviceErrorType, service, serviceClientClass }); %>
+<%_ } else if (getter.parameters != null) { -%>
+<%- include('simple-parameterised-selector.ts.ejs', { getter, serviceErrorType, service, serviceClientClass }); %>
+<%_ } else { -%>
+<%- include('simple-selector.ts.ejs', { getter, serviceErrorType, service, serviceClientClass }); %>
+<%_ } -%>
+<%_ }); -%>
+
+<% if(hasRoles) { -%>
+<%- include('iam-role-scanner.ts.ejs', { iamRoles: locals.iamRoles }); %>
+<%_ } -%>

--- a/aws-scanners/codegen/src/templates/simple-parameterised-selector.ts.ejs
+++ b/aws-scanners/codegen/src/templates/simple-parameterised-selector.ts.ejs
@@ -1,0 +1,33 @@
+export async function <%= getter.id ?? getter.fn %>(
+    client: <%= serviceClientClass %>, 
+    stateConnector: Connector, 
+    context: AwsContext
+): Promise<void> {
+    const state: GenericState[] = [];
+    console.log("<%= service %> <%= getter.id ?? getter.fn %>");
+    const resolvers = <%- JSON.stringify(getter.parameters) %>;
+    const parameterQueue = await resolveFunctionCallParameters(context.account, context.region, resolvers, stateConnector) as <%= getter.id ?? getter.fn %>CommandInput[];
+    for(const parameters of parameterQueue) {
+        const preparedParams: <%= getter.id ?? getter.fn %>CommandInput = parameters;
+        try {
+            const cmd = new <%= getter.fn %>Command(preparedParams);
+            const result: <%= getter.fn %>CommandOutput = await client.send(cmd);
+            state.push({ _metadata: 
+                { account: context.account, region: context.region }, 
+                _parameters: preparedParams, 
+                _result: result 
+            });
+        } catch(err: unknown) {
+            if(err instanceof <%= serviceErrorType %>) {
+                if(err?.$retryable) {
+                    console.log("Encountered retryable error", err);
+                } else {
+                    console.log("Encountered unretryable error", err);
+                }
+            } else {
+                console.log("Encountered unexpected error", err);
+            }
+        }
+    }
+    await stateConnector.onServiceScanCompleteCallback(context.account, context.region, "<%= clientKey %>", "<%= getter.id ?? getter.fn %>", state);
+}

--- a/aws-scanners/codegen/src/templates/simple-selector.ts.ejs
+++ b/aws-scanners/codegen/src/templates/simple-selector.ts.ejs
@@ -1,0 +1,29 @@
+export async function <%= getter.id ?? getter.fn %>(
+    client: <%= serviceClientClass %>, 
+    stateConnector: Connector, 
+    context: AwsContext
+): Promise<void> {
+    const state: GenericState[] = [];
+    console.log("<%= service %> <%= getter.id ?? getter.fn %>");
+    const preparedParams: <%= getter.fn %>CommandInput = {};
+    try {
+        const cmd = new <%= getter.fn %>Command(preparedParams);
+        const result: <%= getter.fn %>CommandOutput = await client.send(cmd);
+        state.push({ _metadata: 
+            { account: context.account, region: context.region }, 
+            _parameters: preparedParams, 
+            _result: result 
+        });
+    } catch(err: unknown) {
+        if(err instanceof <%= serviceErrorType %>) {
+            if(err?.$retryable) {
+                console.log("Encountered retryable error", err);
+            } else {
+                console.log("Encountered unretryable error", err);
+            }
+        } else {
+            console.log("Encountered unexpected error", err);
+        }
+    }
+    await stateConnector.onServiceScanCompleteCallback(context.account, context.region, "<%= clientKey %>", "<%= getter.id ?? getter.fn %>", state);
+}

--- a/aws-scanners/dynamodb/package.json
+++ b/aws-scanners/dynamodb/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/dynamodb/src/generated/getters.ts
+++ b/aws-scanners/dynamodb/src/generated/getters.ts
@@ -1,21 +1,19 @@
+import { resolveFunctionCallParameters } from "@infrascan/core";
 import {
   DynamoDBClient,
-  ListTablesCommand,
-  DescribeTableCommand,
   DynamoDBServiceException,
+  ListTablesCommand,
+  ListTablesCommandInput,
+  ListTablesCommandOutput,
+  DescribeTableCommand,
+  DescribeTableCommandInput,
+  DescribeTableCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-import { resolveFunctionCallParameters } from "@infrascan/core";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  ListTablesCommandInput,
-  ListTablesCommandOutput,
-  DescribeTableCommandInput,
-  DescribeTableCommandOutput,
-} from "@aws-sdk/client-dynamodb";
 
 export async function ListTables(
   client: DynamoDBClient,
@@ -52,7 +50,6 @@ export async function ListTables(
     state,
   );
 }
-
 export async function DescribeTable(
   client: DynamoDBClient,
   stateConnector: Connector,

--- a/aws-scanners/dynamodb/src/generated/graph.ts
+++ b/aws-scanners/dynamodb/src/generated/graph.ts
@@ -18,6 +18,7 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...DescribeTableNodes);
+
   return state.map((node) =>
     formatNode(node, "dynamodb", "DynamoDB", context, true),
   );

--- a/aws-scanners/ec2/package.json
+++ b/aws-scanners/ec2/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/ec2/src/generated/getters.ts
+++ b/aws-scanners/ec2/src/generated/getters.ts
@@ -1,24 +1,22 @@
+import { resolveFunctionCallParameters } from "@infrascan/core";
 import {
   EC2Client,
-  DescribeVpcsCommand,
-  DescribeAvailabilityZonesCommand,
-  DescribeSubnetsCommand,
   EC2ServiceException,
+  DescribeVpcsCommand,
+  DescribeVpcsCommandInput,
+  DescribeVpcsCommandOutput,
+  DescribeAvailabilityZonesCommand,
+  DescribeAvailabilityZonesCommandInput,
+  DescribeAvailabilityZonesCommandOutput,
+  DescribeSubnetsCommand,
+  DescribeSubnetsCommandInput,
+  DescribeSubnetsCommandOutput,
 } from "@aws-sdk/client-ec2";
-import { resolveFunctionCallParameters } from "@infrascan/core";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  DescribeVpcsCommandInput,
-  DescribeVpcsCommandOutput,
-  DescribeAvailabilityZonesCommandInput,
-  DescribeAvailabilityZonesCommandOutput,
-  DescribeSubnetsCommandInput,
-  DescribeSubnetsCommandOutput,
-} from "@aws-sdk/client-ec2";
 
 export async function DescribeVpcs(
   client: EC2Client,
@@ -55,7 +53,6 @@ export async function DescribeVpcs(
     state,
   );
 }
-
 export async function DescribeAvailabilityZones(
   client: EC2Client,
   stateConnector: Connector,
@@ -93,7 +90,6 @@ export async function DescribeAvailabilityZones(
     state,
   );
 }
-
 export async function DescribeSubnets(
   client: EC2Client,
   stateConnector: Connector,
@@ -111,7 +107,7 @@ export async function DescribeSubnets(
     stateConnector,
   )) as DescribeSubnetsCommandInput[];
   for (const parameters of parameterQueue) {
-    let pagingToken: string | undefined = undefined;
+    let pagingToken: string | undefined;
     do {
       const preparedParams: DescribeSubnetsCommandInput = parameters;
       preparedParams.NextToken = pagingToken;

--- a/aws-scanners/ecs/package.json
+++ b/aws-scanners/ecs/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/ecs/src/generated/getters.ts
+++ b/aws-scanners/ecs/src/generated/getters.ts
@@ -1,40 +1,38 @@
 import {
-  ECSClient,
-  ListClustersCommand,
-  DescribeClustersCommand,
-  ListServicesCommand,
-  DescribeServicesCommand,
-  ListTasksCommand,
-  DescribeTasksCommand,
-  DescribeTaskDefinitionCommand,
-  ECSServiceException,
-} from "@aws-sdk/client-ecs";
-import {
   evaluateSelectorGlobally,
   resolveFunctionCallParameters,
 } from "@infrascan/core";
+import {
+  ECSClient,
+  ECSServiceException,
+  ListClustersCommand,
+  ListClustersCommandInput,
+  ListClustersCommandOutput,
+  DescribeClustersCommand,
+  DescribeClustersCommandInput,
+  DescribeClustersCommandOutput,
+  ListServicesCommand,
+  ListServicesCommandInput,
+  ListServicesCommandOutput,
+  DescribeServicesCommand,
+  DescribeServicesCommandInput,
+  DescribeServicesCommandOutput,
+  ListTasksCommand,
+  ListTasksCommandInput,
+  ListTasksCommandOutput,
+  DescribeTasksCommand,
+  DescribeTasksCommandInput,
+  DescribeTasksCommandOutput,
+  DescribeTaskDefinitionCommand,
+  DescribeTaskDefinitionCommandInput,
+  DescribeTaskDefinitionCommandOutput,
+} from "@aws-sdk/client-ecs";
 import type {
   Connector,
   GenericState,
   AwsContext,
   EntityRoleData,
 } from "@infrascan/shared-types";
-import type {
-  ListClustersCommandInput,
-  ListClustersCommandOutput,
-  DescribeClustersCommandInput,
-  DescribeClustersCommandOutput,
-  ListServicesCommandInput,
-  ListServicesCommandOutput,
-  DescribeServicesCommandInput,
-  DescribeServicesCommandOutput,
-  ListTasksCommandInput,
-  ListTasksCommandOutput,
-  DescribeTasksCommandInput,
-  DescribeTasksCommandOutput,
-  DescribeTaskDefinitionCommandInput,
-  DescribeTaskDefinitionCommandOutput,
-} from "@aws-sdk/client-ecs";
 
 export async function ListClusters(
   client: ECSClient,
@@ -71,7 +69,6 @@ export async function ListClusters(
     state,
   );
 }
-
 export async function DescribeClusters(
   client: ECSClient,
   stateConnector: Connector,
@@ -131,7 +128,6 @@ export async function DescribeClusters(
     state,
   );
 }
-
 export async function ListServices(
   client: ECSClient,
   stateConnector: Connector,
@@ -179,7 +175,6 @@ export async function ListServices(
     state,
   );
 }
-
 export async function DescribeServices(
   client: ECSClient,
   stateConnector: Connector,
@@ -231,7 +226,6 @@ export async function DescribeServices(
     state,
   );
 }
-
 export async function ListTasks(
   client: ECSClient,
   stateConnector: Connector,
@@ -278,7 +272,6 @@ export async function ListTasks(
     state,
   );
 }
-
 export async function DescribeTasks(
   client: ECSClient,
   stateConnector: Connector,
@@ -329,7 +322,6 @@ export async function DescribeTasks(
     state,
   );
 }
-
 export async function DescribeTaskDefinition(
   client: ECSClient,
   stateConnector: Connector,
@@ -386,16 +378,16 @@ export async function DescribeTaskDefinition(
 export async function getIamRoles(
   stateConnector: Connector,
 ): Promise<EntityRoleData[]> {
-  let state: EntityRoleData[] = [];
+  const state: EntityRoleData[] = [];
   const DescribeTaskDefinitionRoleState = (await evaluateSelectorGlobally(
     "ECS|DescribeTaskDefinition|[]._result.taskDefinition | [].{roleArn:taskRoleArn,executor:taskDefinitionArn}",
     stateConnector,
   )) as EntityRoleData[];
-  state = state.concat(DescribeTaskDefinitionRoleState);
+  state.push(...DescribeTaskDefinitionRoleState);
   const DescribeTaskDefinitionRoleState1 = (await evaluateSelectorGlobally(
     "ECS|DescribeTaskDefinition|[]._result.taskDefinition | [].{roleArn:executionRoleArn,executor:taskDefinitionArn}",
     stateConnector,
   )) as EntityRoleData[];
-  state = state.concat(DescribeTaskDefinitionRoleState1);
+  state.push(...DescribeTaskDefinitionRoleState1);
   return state;
 }

--- a/aws-scanners/ecs/src/generated/graph.ts
+++ b/aws-scanners/ecs/src/generated/graph.ts
@@ -39,5 +39,6 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...DescribeTasksNodes);
+
   return state.map((node) => formatNode(node, "ecs", "ECS", context, true));
 }

--- a/aws-scanners/ecs/src/index.ts
+++ b/aws-scanners/ecs/src/index.ts
@@ -9,7 +9,7 @@ import {
   ListTasks,
   DescribeTasks,
   DescribeTaskDefinition,
-  getIamRoles
+  getIamRoles,
 } from "./generated/getters";
 import { getNodes } from "./generated/graph";
 
@@ -29,7 +29,7 @@ const ECSScanner: ServiceModule<ECSClient, "aws"> = {
     DescribeTaskDefinition,
   ],
   getNodes,
-  getIamRoles
+  getIamRoles,
 };
 
 export default ECSScanner;

--- a/aws-scanners/elastic-load-balancing/package.json
+++ b/aws-scanners/elastic-load-balancing/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/elastic-load-balancing/src/generated/getters.ts
+++ b/aws-scanners/elastic-load-balancing/src/generated/getters.ts
@@ -1,27 +1,25 @@
+import { resolveFunctionCallParameters } from "@infrascan/core";
 import {
   ElasticLoadBalancingV2Client,
-  DescribeLoadBalancersCommand,
-  DescribeTargetGroupsCommand,
-  DescribeListenersCommand,
-  DescribeRulesCommand,
   ElasticLoadBalancingV2ServiceException,
+  DescribeLoadBalancersCommand,
+  DescribeLoadBalancersCommandInput,
+  DescribeLoadBalancersCommandOutput,
+  DescribeTargetGroupsCommand,
+  DescribeTargetGroupsCommandInput,
+  DescribeTargetGroupsCommandOutput,
+  DescribeListenersCommand,
+  DescribeListenersCommandInput,
+  DescribeListenersCommandOutput,
+  DescribeRulesCommand,
+  DescribeRulesCommandInput,
+  DescribeRulesCommandOutput,
 } from "@aws-sdk/client-elastic-load-balancing-v2";
-import { resolveFunctionCallParameters } from "@infrascan/core";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  DescribeLoadBalancersCommandInput,
-  DescribeLoadBalancersCommandOutput,
-  DescribeTargetGroupsCommandInput,
-  DescribeTargetGroupsCommandOutput,
-  DescribeListenersCommandInput,
-  DescribeListenersCommandOutput,
-  DescribeRulesCommandInput,
-  DescribeRulesCommandOutput,
-} from "@aws-sdk/client-elastic-load-balancing-v2";
 
 export async function DescribeLoadBalancers(
   client: ElasticLoadBalancingV2Client,
@@ -58,7 +56,6 @@ export async function DescribeLoadBalancers(
     state,
   );
 }
-
 export async function DescribeTargetGroups(
   client: ElasticLoadBalancingV2Client,
   stateConnector: Connector,
@@ -109,7 +106,6 @@ export async function DescribeTargetGroups(
     state,
   );
 }
-
 export async function DescribeListeners(
   client: ElasticLoadBalancingV2Client,
   stateConnector: Connector,
@@ -160,7 +156,6 @@ export async function DescribeListeners(
     state,
   );
 }
-
 export async function DescribeRules(
   client: ElasticLoadBalancingV2Client,
   stateConnector: Connector,

--- a/aws-scanners/elastic-load-balancing/src/generated/graph.ts
+++ b/aws-scanners/elastic-load-balancing/src/generated/graph.ts
@@ -18,6 +18,7 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...DescribeLoadBalancersNodes);
+
   return state.map((node) =>
     formatNode(node, "elastic-load-balancing-v2", "ELB", context, true),
   );

--- a/aws-scanners/kinesis/package.json
+++ b/aws-scanners/kinesis/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/kinesis/src/generated/getters.ts
+++ b/aws-scanners/kinesis/src/generated/getters.ts
@@ -1,21 +1,19 @@
+import { resolveFunctionCallParameters } from "@infrascan/core";
 import {
   KinesisClient,
-  ListStreamsCommand,
-  ListStreamConsumersCommand,
   KinesisServiceException,
+  ListStreamsCommand,
+  ListStreamsCommandInput,
+  ListStreamsCommandOutput,
+  ListStreamConsumersCommand,
+  ListStreamConsumersCommandInput,
+  ListStreamConsumersCommandOutput,
 } from "@aws-sdk/client-kinesis";
-import { resolveFunctionCallParameters } from "@infrascan/core";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  ListStreamsCommandInput,
-  ListStreamsCommandOutput,
-  ListStreamConsumersCommandInput,
-  ListStreamConsumersCommandOutput,
-} from "@aws-sdk/client-kinesis";
 
 export async function ListStreams(
   client: KinesisClient,
@@ -24,7 +22,7 @@ export async function ListStreams(
 ): Promise<void> {
   const state: GenericState[] = [];
   console.log("kinesis ListStreams");
-  let pagingToken: string | undefined = undefined;
+  let pagingToken: string | undefined;
   do {
     const preparedParams: ListStreamsCommandInput = {};
     preparedParams.NextToken = pagingToken;
@@ -58,7 +56,6 @@ export async function ListStreams(
     state,
   );
 }
-
 export async function ListStreamConsumers(
   client: KinesisClient,
   stateConnector: Connector,
@@ -79,7 +76,7 @@ export async function ListStreamConsumers(
     stateConnector,
   )) as ListStreamConsumersCommandInput[];
   for (const parameters of parameterQueue) {
-    let pagingToken: string | undefined = undefined;
+    let pagingToken: string | undefined;
     do {
       const preparedParams: ListStreamConsumersCommandInput = parameters;
       preparedParams.NextToken = pagingToken;

--- a/aws-scanners/kinesis/src/generated/graph.ts
+++ b/aws-scanners/kinesis/src/generated/graph.ts
@@ -33,6 +33,7 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...ListStreamConsumersNodes);
+
   return state.map((node) =>
     formatNode(node, "kinesis", "Kinesis", context, true),
   );

--- a/aws-scanners/lambda/package.json
+++ b/aws-scanners/lambda/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/lambda/src/generated/getters.ts
+++ b/aws-scanners/lambda/src/generated/getters.ts
@@ -1,25 +1,23 @@
 import {
-  LambdaClient,
-  ListFunctionsCommand,
-  GetFunctionCommand,
-  LambdaServiceException,
-} from "@aws-sdk/client-lambda";
-import {
   evaluateSelectorGlobally,
   resolveFunctionCallParameters,
 } from "@infrascan/core";
+import {
+  LambdaClient,
+  LambdaServiceException,
+  ListFunctionsCommand,
+  ListFunctionsCommandInput,
+  ListFunctionsCommandOutput,
+  GetFunctionCommand,
+  GetFunctionCommandInput,
+  GetFunctionCommandOutput,
+} from "@aws-sdk/client-lambda";
 import type {
   Connector,
   GenericState,
   AwsContext,
   EntityRoleData,
 } from "@infrascan/shared-types";
-import type {
-  ListFunctionsCommandInput,
-  ListFunctionsCommandOutput,
-  GetFunctionCommandInput,
-  GetFunctionCommandOutput,
-} from "@aws-sdk/client-lambda";
 
 export async function ListFunctions(
   client: LambdaClient,
@@ -28,7 +26,7 @@ export async function ListFunctions(
 ): Promise<void> {
   const state: GenericState[] = [];
   console.log("lambda ListFunctions");
-  let pagingToken: string | undefined = undefined;
+  let pagingToken: string | undefined;
   do {
     const preparedParams: ListFunctionsCommandInput = {};
     preparedParams.Marker = pagingToken;
@@ -62,7 +60,6 @@ export async function ListFunctions(
     state,
   );
 }
-
 export async function GetFunction(
   client: LambdaClient,
   stateConnector: Connector,
@@ -116,11 +113,11 @@ export async function GetFunction(
 export async function getIamRoles(
   stateConnector: Connector,
 ): Promise<EntityRoleData[]> {
-  let state: EntityRoleData[] = [];
+  const state: EntityRoleData[] = [];
   const GetFunctionRoleState = (await evaluateSelectorGlobally(
     "Lambda|GetFunction|[]._result.Configuration | [].{roleArn:Role,executor:FunctionArn}",
     stateConnector,
   )) as EntityRoleData[];
-  state = state.concat(GetFunctionRoleState);
+  state.push(...GetFunctionRoleState);
   return state;
 }

--- a/aws-scanners/lambda/src/generated/graph.ts
+++ b/aws-scanners/lambda/src/generated/graph.ts
@@ -18,6 +18,7 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...ListFunctionsNodes);
+
   return state.map((node) =>
     formatNode(node, "lambda", "Lambda", context, true),
   );

--- a/aws-scanners/rds/package.json
+++ b/aws-scanners/rds/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/rds/src/generated/getters.ts
+++ b/aws-scanners/rds/src/generated/getters.ts
@@ -1,17 +1,15 @@
 import {
   RDSClient,
-  DescribeDBInstancesCommand,
   RDSServiceException,
+  DescribeDBInstancesCommand,
+  DescribeDBInstancesCommandInput,
+  DescribeDBInstancesCommandOutput,
 } from "@aws-sdk/client-rds";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  DescribeDBInstancesCommandInput,
-  DescribeDBInstancesCommandOutput,
-} from "@aws-sdk/client-rds";
 
 export async function DescribeDBInstances(
   client: RDSClient,

--- a/aws-scanners/rds/src/generated/graph.ts
+++ b/aws-scanners/rds/src/generated/graph.ts
@@ -18,5 +18,6 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...DescribeDBInstancesNodes);
+
   return state.map((node) => formatNode(node, "rds", "RDS", context, true));
 }

--- a/aws-scanners/route53/package.json
+++ b/aws-scanners/route53/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/route53/src/generated/getters.ts
+++ b/aws-scanners/route53/src/generated/getters.ts
@@ -1,21 +1,19 @@
+import { resolveFunctionCallParameters } from "@infrascan/core";
 import {
   Route53Client,
-  ListHostedZonesByNameCommand,
-  ListResourceRecordSetsCommand,
   Route53ServiceException,
+  ListHostedZonesByNameCommand,
+  ListHostedZonesByNameCommandInput,
+  ListHostedZonesByNameCommandOutput,
+  ListResourceRecordSetsCommand,
+  ListResourceRecordSetsCommandInput,
+  ListResourceRecordSetsCommandOutput,
 } from "@aws-sdk/client-route-53";
-import { resolveFunctionCallParameters } from "@infrascan/core";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  ListHostedZonesByNameCommandInput,
-  ListHostedZonesByNameCommandOutput,
-  ListResourceRecordSetsCommandInput,
-  ListResourceRecordSetsCommandOutput,
-} from "@aws-sdk/client-route-53";
 
 export async function ListHostedZonesByName(
   client: Route53Client,
@@ -52,7 +50,6 @@ export async function ListHostedZonesByName(
     state,
   );
 }
-
 export async function ListResourceRecordSets(
   client: Route53Client,
   stateConnector: Connector,

--- a/aws-scanners/route53/src/generated/graph.ts
+++ b/aws-scanners/route53/src/generated/graph.ts
@@ -18,6 +18,7 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...ListResourceRecordSetsNodes);
+
   return state.map((node) =>
     formatNode(node, "route-53", "Route53", context, false),
   );

--- a/aws-scanners/s3/package.json
+++ b/aws-scanners/s3/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/s3/src/generated/getters.ts
+++ b/aws-scanners/s3/src/generated/getters.ts
@@ -1,30 +1,28 @@
+import { resolveFunctionCallParameters } from "@infrascan/core";
 import {
   S3Client,
-  ListBucketsCommand,
-  GetBucketTaggingCommand,
-  GetBucketNotificationConfigurationCommand,
-  GetBucketWebsiteCommand,
-  GetBucketAclCommand,
   S3ServiceException,
+  ListBucketsCommand,
+  ListBucketsCommandInput,
+  ListBucketsCommandOutput,
+  GetBucketTaggingCommand,
+  GetBucketTaggingCommandInput,
+  GetBucketTaggingCommandOutput,
+  GetBucketNotificationConfigurationCommand,
+  GetBucketNotificationConfigurationCommandInput,
+  GetBucketNotificationConfigurationCommandOutput,
+  GetBucketWebsiteCommand,
+  GetBucketWebsiteCommandInput,
+  GetBucketWebsiteCommandOutput,
+  GetBucketAclCommand,
+  GetBucketAclCommandInput,
+  GetBucketAclCommandOutput,
 } from "@aws-sdk/client-s3";
-import { resolveFunctionCallParameters } from "@infrascan/core";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  ListBucketsCommandInput,
-  ListBucketsCommandOutput,
-  GetBucketTaggingCommandInput,
-  GetBucketTaggingCommandOutput,
-  GetBucketNotificationConfigurationCommandInput,
-  GetBucketNotificationConfigurationCommandOutput,
-  GetBucketWebsiteCommandInput,
-  GetBucketWebsiteCommandOutput,
-  GetBucketAclCommandInput,
-  GetBucketAclCommandOutput,
-} from "@aws-sdk/client-s3";
 
 export async function ListBuckets(
   client: S3Client,
@@ -61,7 +59,6 @@ export async function ListBuckets(
     state,
   );
 }
-
 export async function GetBucketTagging(
   client: S3Client,
   stateConnector: Connector,
@@ -108,7 +105,6 @@ export async function GetBucketTagging(
     state,
   );
 }
-
 export async function GetBucketNotificationConfiguration(
   client: S3Client,
   stateConnector: Connector,
@@ -157,7 +153,6 @@ export async function GetBucketNotificationConfiguration(
     state,
   );
 }
-
 export async function GetBucketWebsite(
   client: S3Client,
   stateConnector: Connector,
@@ -204,7 +199,6 @@ export async function GetBucketWebsite(
     state,
   );
 }
-
 export async function GetBucketAcl(
   client: S3Client,
   stateConnector: Connector,

--- a/aws-scanners/s3/src/generated/graph.ts
+++ b/aws-scanners/s3/src/generated/graph.ts
@@ -26,6 +26,7 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...ListBucketsNodes);
+
   return state.map((node) => formatNode(node, "s3", "S3", context, false));
 }
 

--- a/aws-scanners/sns/package.json
+++ b/aws-scanners/sns/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/sns/src/generated/getters.ts
+++ b/aws-scanners/sns/src/generated/getters.ts
@@ -1,27 +1,25 @@
+import { resolveFunctionCallParameters } from "@infrascan/core";
 import {
   SNSClient,
-  ListTopicsCommand,
-  GetTopicAttributesCommand,
-  ListSubscriptionsByTopicCommand,
-  ListTagsForResourceCommand,
   SNSServiceException,
+  ListTopicsCommand,
+  ListTopicsCommandInput,
+  ListTopicsCommandOutput,
+  GetTopicAttributesCommand,
+  GetTopicAttributesCommandInput,
+  GetTopicAttributesCommandOutput,
+  ListSubscriptionsByTopicCommand,
+  ListSubscriptionsByTopicCommandInput,
+  ListSubscriptionsByTopicCommandOutput,
+  ListTagsForResourceCommand,
+  ListTagsForResourceCommandInput,
+  ListTagsForResourceCommandOutput,
 } from "@aws-sdk/client-sns";
-import { resolveFunctionCallParameters } from "@infrascan/core";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  ListTopicsCommandInput,
-  ListTopicsCommandOutput,
-  GetTopicAttributesCommandInput,
-  GetTopicAttributesCommandOutput,
-  ListSubscriptionsByTopicCommandInput,
-  ListSubscriptionsByTopicCommandOutput,
-  ListTagsForResourceCommandInput,
-  ListTagsForResourceCommandOutput,
-} from "@aws-sdk/client-sns";
 
 export async function ListTopics(
   client: SNSClient,
@@ -58,7 +56,6 @@ export async function ListTopics(
     state,
   );
 }
-
 export async function GetTopicAttributes(
   client: SNSClient,
   stateConnector: Connector,
@@ -108,7 +105,6 @@ export async function GetTopicAttributes(
     state,
   );
 }
-
 export async function ListSubscriptionsByTopic(
   client: SNSClient,
   stateConnector: Connector,
@@ -160,7 +156,6 @@ export async function ListSubscriptionsByTopic(
     state,
   );
 }
-
 export async function ListTagsForResource(
   client: SNSClient,
   stateConnector: Connector,

--- a/aws-scanners/sns/src/generated/graph.ts
+++ b/aws-scanners/sns/src/generated/graph.ts
@@ -26,6 +26,7 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...ListTopicsNodes);
+
   return state.map((node) => formatNode(node, "sns", "SNS", context, true));
 }
 

--- a/aws-scanners/sqs/package.json
+++ b/aws-scanners/sqs/package.json
@@ -22,7 +22,7 @@
     "splitting": false,
     "sourcemap": false,
     "entry": [
-      "src/index.ts"
+      "src/**/*.ts"
     ],
     "format": [
       "cjs",

--- a/aws-scanners/sqs/src/generated/getters.ts
+++ b/aws-scanners/sqs/src/generated/getters.ts
@@ -1,24 +1,22 @@
+import { resolveFunctionCallParameters } from "@infrascan/core";
 import {
   SQSClient,
-  ListQueuesCommand,
-  ListQueueTagsCommand,
-  GetQueueAttributesCommand,
   SQSServiceException,
+  ListQueuesCommand,
+  ListQueuesCommandInput,
+  ListQueuesCommandOutput,
+  ListQueueTagsCommand,
+  ListQueueTagsCommandInput,
+  ListQueueTagsCommandOutput,
+  GetQueueAttributesCommand,
+  GetQueueAttributesCommandInput,
+  GetQueueAttributesCommandOutput,
 } from "@aws-sdk/client-sqs";
-import { resolveFunctionCallParameters } from "@infrascan/core";
 import type {
   Connector,
   GenericState,
   AwsContext,
 } from "@infrascan/shared-types";
-import type {
-  ListQueuesCommandInput,
-  ListQueuesCommandOutput,
-  ListQueueTagsCommandInput,
-  ListQueueTagsCommandOutput,
-  GetQueueAttributesCommandInput,
-  GetQueueAttributesCommandOutput,
-} from "@aws-sdk/client-sqs";
 
 export async function ListQueues(
   client: SQSClient,
@@ -55,7 +53,6 @@ export async function ListQueues(
     state,
   );
 }
-
 export async function ListQueueTags(
   client: SQSClient,
   stateConnector: Connector,
@@ -102,7 +99,6 @@ export async function ListQueueTags(
     state,
   );
 }
-
 export async function GetQueueAttributes(
   client: SQSClient,
   stateConnector: Connector,

--- a/aws-scanners/sqs/src/generated/graph.ts
+++ b/aws-scanners/sqs/src/generated/graph.ts
@@ -18,5 +18,6 @@ export async function getNodes(
     stateConnector,
   );
   state.push(...GetQueueAttributesNodes);
+
   return state.map((node) => formatNode(node, "sqs", "SQS", context, true));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,11 +459,12 @@
       "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "ts-morph": "^19.0.0",
+        "ejs": "^3.1.9",
         "typescript": "^5.1.3"
       },
       "devDependencies": {
         "@infrascan/shared-types": "^0.2.0",
+        "@types/ejs": "^3.1.5",
         "@types/node": "^20.3.1",
         "eslint-config-custom": "*",
         "ts-node": "^10.9.1",
@@ -8317,45 +8318,6 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true
     },
-    "node_modules/@ts-morph/common": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.20.0.tgz",
-      "integrity": "sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==",
-      "dependencies": {
-        "fast-glob": "^3.2.12",
-        "minimatch": "^7.4.3",
-        "mkdirp": "^2.1.6",
-        "path-browserify": "^1.0.1"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/mkdirp": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
-      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -8551,6 +8513,12 @@
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA=="
+    },
+    "node_modules/@types/ejs": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.5.tgz",
+      "integrity": "sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==",
+      "dev": true
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -9193,6 +9161,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+    },
     "node_modules/async-hook-domain": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-4.0.1.tgz",
@@ -9320,6 +9293,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -9971,11 +9945,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/code-block-writer": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-12.0.0.tgz",
-      "integrity": "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w=="
-    },
     "node_modules/code-excerpt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
@@ -10356,6 +10325,20 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ejs": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -11244,6 +11227,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
       "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -11259,6 +11243,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -11331,10 +11316,30 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -12694,6 +12699,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -12983,6 +12989,107 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jake/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jake/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jake/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jake/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/jake/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jake/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jake/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jmespath": {
@@ -13371,6 +13478,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -13379,6 +13487,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -14647,11 +14756,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
-    },
     "node_modules/path-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
@@ -14750,6 +14854,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -16841,6 +16946,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -16889,15 +16995,6 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
-    },
-    "node_modules/ts-morph": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-19.0.0.tgz",
-      "integrity": "sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==",
-      "dependencies": {
-        "@ts-morph/common": "~0.20.0",
-        "code-block-writer": "^12.0.0"
-      }
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
@@ -22670,9 +22767,10 @@
       "version": "file:aws-scanners/codegen",
       "requires": {
         "@infrascan/shared-types": "^0.2.0",
+        "@types/ejs": "^3.1.5",
         "@types/node": "^20.3.1",
+        "ejs": "^3.1.9",
         "eslint-config-custom": "*",
-        "ts-morph": "^19.0.0",
         "ts-node": "^10.9.1",
         "tsconfig": "*",
         "typescript": "^5.1.3"
@@ -24897,32 +24995,6 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true
     },
-    "@ts-morph/common": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.20.0.tgz",
-      "integrity": "sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==",
-      "requires": {
-        "fast-glob": "^3.2.12",
-        "minimatch": "^7.4.3",
-        "mkdirp": "^2.1.6",
-        "path-browserify": "^1.0.1"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
-        "mkdirp": {
-          "version": "2.1.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
-          "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A=="
-        }
-      }
-    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -25091,6 +25163,12 @@
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA=="
+    },
+    "@types/ejs": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.5.tgz",
+      "integrity": "sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==",
+      "dev": true
     },
     "@types/glob": {
       "version": "7.2.0",
@@ -25555,6 +25633,11 @@
         "tslib": "^2.0.1"
       }
     },
+    "async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+    },
     "async-hook-domain": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-4.0.1.tgz",
@@ -25644,6 +25727,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -26094,11 +26178,6 @@
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true
     },
-    "code-block-writer": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-12.0.0.tgz",
-      "integrity": "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w=="
-    },
     "code-excerpt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
@@ -26398,6 +26477,14 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "ejs": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "requires": {
+        "jake": "^10.8.5"
+      }
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -27175,6 +27262,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
       "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -27187,6 +27275,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -27236,10 +27325,29 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "requires": {
+        "minimatch": "^5.0.1"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -28207,7 +28315,8 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-number-object": {
       "version": "1.0.7",
@@ -28401,6 +28510,79 @@
       "requires": {
         "@isaacs/cliui": "^8.0.2",
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "jake": {
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
+      "requires": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jmespath": {
@@ -28712,12 +28894,14 @@
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
     },
     "micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -29706,11 +29890,6 @@
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
       "dev": true
     },
-    "path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
-    },
     "path-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
@@ -29791,7 +29970,8 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -31318,6 +31498,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -31354,15 +31535,6 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
-    },
-    "ts-morph": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-19.0.0.tgz",
-      "integrity": "sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==",
-      "requires": {
-        "@ts-morph/common": "~0.20.0",
-        "code-block-writer": "^12.0.0"
-      }
     },
     "ts-node": {
       "version": "10.9.1",

--- a/packages/sdk/src/graph.ts
+++ b/packages/sdk/src/graph.ts
@@ -94,7 +94,9 @@ export function addGraphEdgeToMap(
   if (hasSource && hasTarget) {
     addGraphElementToMap(edgeMap, element);
   } else {
-    console.warn(`Found edge with missing source or target: ${source} -> ${target}`);
+    console.warn(
+      `Found edge with missing source or target: ${source} -> ${target}`,
+    );
   }
 }
 
@@ -209,7 +211,9 @@ export async function generateEdgesForPolicyStatements(
 ): Promise<EdgeResource[]> {
   let resources: EdgeResource[] = [];
   for (const { label, statements } of policyStatements) {
-    const mappedStatements = Array.isArray(statements) ? statements : [statements];
+    const mappedStatements = Array.isArray(statements)
+      ? statements
+      : [statements];
     for (const statement of mappedStatements) {
       const { Resource } = statement;
       if (Array.isArray(Resource)) {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -307,7 +307,9 @@ export default class Infrascan {
       if (scanner.getEdges != null) {
         console.log(`Getting Edges: ${scanner.service}`);
         const scannerEdges: GraphEdge[] = await scanner.getEdges(connector);
-        scannerEdges.forEach((edge) => addGraphEdgeToMap(graphNodes, graphEdges, edge));
+        scannerEdges.forEach((edge) =>
+          addGraphEdgeToMap(graphNodes, graphEdges, edge),
+        );
       }
     }
 

--- a/packages/sdk/src/scan.ts
+++ b/packages/sdk/src/scan.ts
@@ -107,8 +107,8 @@ export async function scanService(
     await Promise.all(
       iamRoles.map(({ roleArn }) =>
         scanIamRole(iamStorage, iamClient, roleArn).catch((err) => {
-          console.error("An error occurred while scanning role:",roleArn);
-          if(err instanceof Error) {
+          console.error("An error occurred while scanning role:", roleArn);
+          if (err instanceof Error) {
             console.error(err.message);
           }
         }),


### PR DESCRIPTION
Codegen previously used ts-morph in one spaghetti script. This PR migrates the codegen logic to use `ejs` templates. 

`ejs` gives similar flexibility to the ts-morph script but is far easier to reason about and allows the templates to be broken down.