### PR TITLE
Patch: Update EC2 scanner to better handle VPCs, AZs and Subnets

### DIFF
--- a/.changeset/rotten-snakes-tap.md
+++ b/.changeset/rotten-snakes-tap.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/aws-ec2-scanner": patch
+---
+
+Update EC2 scanner to correctly build the hierarchy between VPC, AZ, and subnets

--- a/aws-scanners/ec2/config.ts
+++ b/aws-scanners/ec2/config.ts
@@ -20,14 +20,11 @@ const CloudWatchLogsScanner: ScannerDefinition<
       fn: "DescribeVpcs",
     },
     {
-      fn: "DescribeAvailabilityZones",
-    },
-    {
       fn: "DescribeSubnets",
       parameters: [
         {
           Key: "Filters",
-          Selector: "EC2|DescribeVpcs|[]._result[]|[].VpcId"
+          Selector: "EC2|DescribeVpcs|[]._result[].Vpcs[].VpcId"
         }
       ],
       paginationToken: {

--- a/aws-scanners/ec2/package.json
+++ b/aws-scanners/ec2/package.json
@@ -57,10 +57,13 @@
   },
   "homepage": "https://github.com/infrascan/infrascan#readme",
   "devDependencies": {
+    "@aws-sdk/credential-providers": "^3.501.0",
     "@infrascan/aws-codegen": "^0.1.0",
+    "@infrascan/fs-connector": "^0.2.3",
     "@infrascan/shared-types": "^0.2.4",
     "aws-sdk-client-mock": "^3.0.1",
     "eslint-config-codegen": "^1.0.0",
+    "tap": "^18.7.0",
     "tsconfig": "^0.0.0"
   },
   "dependencies": {

--- a/aws-scanners/ec2/package.json
+++ b/aws-scanners/ec2/package.json
@@ -34,7 +34,7 @@
     "codegen": "npx ts-node ./codegen.ts ; npm run lint:fix ; npm run fmt",
     "build": "rm -rf dist ; tsup",
     "prepublish": "rm -rf dist ; tsup",
-    "test": "echo \"Error: no test specified\"",
+    "test": "tap test/*.test.ts --allow-incomplete-coverage -- --typescript",
     "lint": "tsc --noEmit ; prettier src/**/*.ts -c ; eslint .",
     "lint:fix": "eslint . --fix",
     "fmt": "prettier src/**/*.ts -w",
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@infrascan/aws-codegen": "^0.1.0",
     "@infrascan/shared-types": "^0.2.4",
+    "aws-sdk-client-mock": "^3.0.1",
     "eslint-config-codegen": "^1.0.0",
     "tsconfig": "^0.0.0"
   },

--- a/aws-scanners/ec2/src/generated/getters.ts
+++ b/aws-scanners/ec2/src/generated/getters.ts
@@ -5,9 +5,6 @@ import {
   DescribeVpcsCommand,
   DescribeVpcsCommandInput,
   DescribeVpcsCommandOutput,
-  DescribeAvailabilityZonesCommand,
-  DescribeAvailabilityZonesCommandInput,
-  DescribeAvailabilityZonesCommandOutput,
   DescribeSubnetsCommand,
   DescribeSubnetsCommandInput,
   DescribeSubnetsCommandOutput,
@@ -53,43 +50,6 @@ export async function DescribeVpcs(
     state,
   );
 }
-export async function DescribeAvailabilityZones(
-  client: EC2Client,
-  stateConnector: Connector,
-  context: AwsContext,
-): Promise<void> {
-  const state: GenericState[] = [];
-  console.log("ec2 DescribeAvailabilityZones");
-  const preparedParams: DescribeAvailabilityZonesCommandInput = {};
-  try {
-    const cmd = new DescribeAvailabilityZonesCommand(preparedParams);
-    const result: DescribeAvailabilityZonesCommandOutput = await client.send(
-      cmd,
-    );
-    state.push({
-      _metadata: { account: context.account, region: context.region },
-      _parameters: preparedParams,
-      _result: result,
-    });
-  } catch (err: unknown) {
-    if (err instanceof EC2ServiceException) {
-      if (err?.$retryable) {
-        console.log("Encountered retryable error", err);
-      } else {
-        console.log("Encountered unretryable error", err);
-      }
-    } else {
-      console.log("Encountered unexpected error", err);
-    }
-  }
-  await stateConnector.onServiceScanCompleteCallback(
-    context.account,
-    context.region,
-    "EC2",
-    "DescribeAvailabilityZones",
-    state,
-  );
-}
 export async function DescribeSubnets(
   client: EC2Client,
   stateConnector: Connector,
@@ -98,7 +58,7 @@ export async function DescribeSubnets(
   const state: GenericState[] = [];
   console.log("ec2 DescribeSubnets");
   const resolvers = [
-    { Key: "Filters", Selector: "EC2|DescribeVpcs|[]._result[]|[].VpcId" },
+    { Key: "Filters", Selector: "EC2|DescribeVpcs|[]._result[].Vpcs[].VpcId" },
   ];
   const parameterQueue = (await resolveFunctionCallParameters(
     context.account,

--- a/aws-scanners/ec2/src/graph.ts
+++ b/aws-scanners/ec2/src/graph.ts
@@ -6,7 +6,6 @@ import type {
   State,
 } from "@infrascan/shared-types";
 import type {
-  DescribeSubnetsCommandOutput,
   DescribeVpcsCommandOutput,
   Subnet,
 } from "@aws-sdk/client-ec2";

--- a/aws-scanners/ec2/src/index.ts
+++ b/aws-scanners/ec2/src/index.ts
@@ -3,7 +3,6 @@ import type { ServiceModule } from "@infrascan/shared-types";
 import { getClient } from "./generated/client";
 import {
   DescribeVpcs,
-  DescribeAvailabilityZones,
   DescribeSubnets,
 } from "./generated/getters";
 import { getNodes } from "./graph";
@@ -15,7 +14,7 @@ const EC2Scanner: ServiceModule<EC2Client, "aws"> = {
   key: "EC2-Networking",
   getClient,
   callPerRegion: true,
-  getters: [DescribeVpcs, DescribeAvailabilityZones, DescribeSubnets],
+  getters: [DescribeVpcs, DescribeSubnets],
   getNodes,
 };
 

--- a/aws-scanners/ec2/test/index.test.ts
+++ b/aws-scanners/ec2/test/index.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { env } from "process";
+import t from "tap";
+import { mockClient } from "aws-sdk-client-mock";
+import { fromProcess } from "@aws-sdk/credential-providers";
+import {
+    DescribeVpcsCommand,
+    DescribeSubnetsCommand
+} from "@aws-sdk/client-ec2";
+import buildFsConnector from "@infrascan/fs-connector";
+import EC2Scanner from "../src";
+
+const stateDirectoryPrefix = "infrascan-test-state-";
+const baseDirectory =
+    env.DEBUG_STATE != null
+        ? stateDirectoryPrefix
+        : join(tmpdir(), stateDirectoryPrefix);
+const tmpDir = mkdtempSync(baseDirectory);
+const connector = buildFsConnector(tmpDir);
+
+t.test(
+    "When no VPCs are returned, subnets aren't scanned",
+    async () => {
+        const testContext = {
+            region: "us-east-1",
+            account: "0".repeat(8),
+        };
+        const ec2Client = EC2Scanner.getClient(fromProcess(), testContext);
+
+        const mockedEc2Client = mockClient(ec2Client);
+
+        mockedEc2Client.on(DescribeVpcsCommand).resolves({
+            Vpcs: []
+        });
+
+        for (const scannerFn of EC2Scanner.getters) {
+            await scannerFn(ec2Client, connector, testContext);
+        }
+
+        t.equal(mockedEc2Client.commandCalls(DescribeVpcsCommand).length, 1);
+        t.equal(mockedEc2Client.commandCalls(DescribeSubnetsCommand).length, 0);
+    });
+
+t.test(
+    "When VPCs are returned, scans subnets and builds the expected hierarchy",
+    async () => {
+        const testContext = {
+            region: "us-east-1",
+            account: "0".repeat(8),
+        };
+        const ec2Client = EC2Scanner.getClient(fromProcess(), testContext);
+
+        const mockedEc2Client = mockClient(ec2Client);
+
+        const testVpcId = 'test-vpc-000000000';
+        const testVpcCidr = '10.0.0.0/22';
+        mockedEc2Client.on(DescribeVpcsCommand).resolves({
+            Vpcs: [{
+                VpcId: testVpcId,
+                CidrBlock: testVpcCidr
+            }]
+        });
+
+        const testSubnetId1 = 'subnet-000000000001';
+        const testSubnetId2 = 'subnet-000000000002';
+        const testSubnetArn1 = `arn:aws:ec2:eu-west-1:00000000000:subnet/${testSubnetId1}`;
+        const testSubnetArn2 = `arn:aws:ec2:eu-west-1:00000000000:subnet/${testSubnetId2}`;
+        const testAZ1 = 'eu-west-1a';
+        const testAZ2 = 'eu-west-1b';
+        const testAZID1 = 'euw1-az1';
+        const testAZID2 = 'euw1-az2';
+        const testCidrBlock1 = '10.0.1.0/24';
+        const testCidrBlock2 = '10.0.2.0/24';
+        mockedEc2Client.on(DescribeSubnetsCommand).resolves({
+            Subnets: [{
+                SubnetArn: testSubnetArn1,
+                SubnetId: testSubnetId1,
+                AvailabilityZone: testAZ1,
+                AvailabilityZoneId: testAZID1,
+                CidrBlock: testCidrBlock1,
+                VpcId: testVpcId,
+            }, {
+                SubnetArn: testSubnetArn2,
+                SubnetId: testSubnetId2,
+                AvailabilityZone: testAZ2,
+                AvailabilityZoneId: testAZID2,
+                CidrBlock: testCidrBlock2,
+                VpcId: testVpcId,
+            }]
+        });
+
+        for (const scannerFn of EC2Scanner.getters) {
+            await scannerFn(ec2Client, connector, testContext);
+        }
+
+        t.equal(mockedEc2Client.commandCalls(DescribeVpcsCommand).length, 1);
+        t.equal(mockedEc2Client.commandCalls(DescribeSubnetsCommand).length, 1);
+
+        const nodes = await EC2Scanner.getNodes!(connector, testContext);
+        t.equal(nodes.length, 5);
+
+        // Node for VPC found
+        t.ok(nodes.find((node) => node.data.id === testVpcId));
+        // Node for Subnet's AZ found with VPC as parent
+        t.ok(nodes.find((node) => node.data.id === `${testVpcId}-${testAZ1}` && node.data.parent === testVpcId));
+        t.ok(nodes.find((node) => node.data.id === `${testVpcId}-${testAZ2}` && node.data.parent === testVpcId));
+        // Node for Subnets found with AZ as parent
+        t.ok(nodes.find((node) => node.data.id === testSubnetId1 && node.data.parent === `${testVpcId}-${testAZ1}`));
+        t.ok(nodes.find((node) => node.data.id === testSubnetId2 && node.data.parent === `${testVpcId}-${testAZ2}`));
+    });  

--- a/package-lock.json
+++ b/package-lock.json
@@ -495,11 +495,296 @@
         "@infrascan/core": "0.2.2"
       },
       "devDependencies": {
+        "@aws-sdk/credential-providers": "^3.501.0",
         "@infrascan/aws-codegen": "^0.1.0",
+        "@infrascan/fs-connector": "^0.2.3",
         "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.1",
         "eslint-config-codegen": "^1.0.0",
+        "tap": "^18.7.0",
         "tsconfig": "^0.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.501.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.501.0.tgz",
+      "integrity": "sha512-ynWW9VVT7CTMQBh8l7WFt2SNekg3667gwjQmeGN8+DDMDqt2Z+L52717S0AN1pQDUMbh/DuKKPk+Sr30HBK3vA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.501.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/credential-provider-node": "3.501.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-signing": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
+      "version": "3.501.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.501.0.tgz",
+      "integrity": "sha512-Uwc/xuxsA46dZS5s+4U703LBNDrGpWF7RB4XYEEMD21BLfGuqntxLLQux8xxKt3Pcur0CsXNja5jXt3uLnE5MA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/credential-provider-node": "3.501.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.501.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.501.0.tgz",
+      "integrity": "sha512-NM62D8gYrQ1nyLYwW4k48B2/lMHDzHDcQccS1wJakr6bg5sdtG06CumwlVcY+LAa0o1xRnhHmh/yiwj/nN4avw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.496.0",
+        "@aws-sdk/credential-provider-ini": "3.501.0",
+        "@aws-sdk/credential-provider-process": "3.496.0",
+        "@aws-sdk/credential-provider-sso": "3.501.0",
+        "@aws-sdk/credential-provider-web-identity": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+      "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "aws-scanners/ec2/node_modules/@aws-sdk/client-ec2": {
@@ -553,6 +838,194 @@
         "node": ">=14.0.0"
       }
     },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-sso": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
     "aws-scanners/ec2/node_modules/@aws-sdk/client-sts": {
       "version": "3.428.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.428.0.tgz",
@@ -599,6 +1072,663 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/core": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
+      "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/core": "^1.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.501.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.501.0.tgz",
+      "integrity": "sha512-U9fjzliKzMiPx/EWLNLCEoF5wWhVtlluTEc4/WhNtSryV2PyihqIAK8nK4+MFaXB4xOrlRnpYMd7oqm03wMGyw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.501.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.496.0.tgz",
+      "integrity": "sha512-iphFlFX0qDFsE24XmFlcKmsR4uyNaqQrK+Y18mwSZMs1yWtL4Sck0rcTXU/cU2W3/xisjh7xFXK5L5aowjMZOg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.501.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.501.0.tgz",
+      "integrity": "sha512-6UXnwLtYIr298ljveumCVXsH+x7csGscK5ylY+veRFy514NqyloRdJt8JY26hhh5SF9MYnkW+JyWSJ2Ls3tOjQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.496.0",
+        "@aws-sdk/credential-provider-process": "3.496.0",
+        "@aws-sdk/credential-provider-sso": "3.501.0",
+        "@aws-sdk/credential-provider-web-identity": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.501.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.501.0.tgz",
+      "integrity": "sha512-y90dlvvZ55PwecODFdMx0NiNlJJfm7X6S61PKdLNCMRcu1YK+eWn0CmPHGHobBUQ4SEYhnFLcHSsf+VMim6BtQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.496.0",
+        "@aws-sdk/token-providers": "3.501.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers": {
+      "version": "3.501.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.501.0.tgz",
+      "integrity": "sha512-nyfGzzYKcAny2kUyQjVDhSzfFTwkfZjGyJZ79WaLkNcCsVSsHBbptPRmRV2b4N0EoHTCfGqkbB02as4av/OQrw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.501.0",
+        "@aws-sdk/client-sso": "3.496.0",
+        "@aws-sdk/client-sts": "3.501.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.501.0",
+        "@aws-sdk/credential-provider-env": "3.496.0",
+        "@aws-sdk/credential-provider-http": "3.496.0",
+        "@aws-sdk/credential-provider-ini": "3.501.0",
+        "@aws-sdk/credential-provider-node": "3.501.0",
+        "@aws-sdk/credential-provider-process": "3.496.0",
+        "@aws-sdk/credential-provider-sso": "3.501.0",
+        "@aws-sdk/credential-provider-web-identity": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
+      "version": "3.501.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.501.0.tgz",
+      "integrity": "sha512-Uwc/xuxsA46dZS5s+4U703LBNDrGpWF7RB4XYEEMD21BLfGuqntxLLQux8xxKt3Pcur0CsXNja5jXt3uLnE5MA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.496.0",
+        "@aws-sdk/credential-provider-node": "3.501.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.501.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.501.0.tgz",
+      "integrity": "sha512-NM62D8gYrQ1nyLYwW4k48B2/lMHDzHDcQccS1wJakr6bg5sdtG06CumwlVcY+LAa0o1xRnhHmh/yiwj/nN4avw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.496.0",
+        "@aws-sdk/credential-provider-ini": "3.501.0",
+        "@aws-sdk/credential-provider-process": "3.496.0",
+        "@aws-sdk/credential-provider-sso": "3.501.0",
+        "@aws-sdk/credential-provider-web-identity": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/token-providers": {
+      "version": "3.501.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.501.0.tgz",
+      "integrity": "sha512-MvLPhNxlStmQqVm2crGLUqYWvK/AbMmI9j4FbEfJ15oG/I+730zjSJQEy2MvdiqbJRDPZ/tRCL89bUedOrmi0g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.496.0",
+        "@aws-sdk/middleware-logger": "3.496.0",
+        "@aws-sdk/middleware-recursion-detection": "3.496.0",
+        "@aws-sdk/middleware-user-agent": "3.496.0",
+        "@aws-sdk/region-config-resolver": "3.496.0",
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@aws-sdk/util-user-agent-browser": "3.496.0",
+        "@aws-sdk/util-user-agent-node": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.1.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@aws-sdk/util-endpoints": "3.496.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+      "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "aws-scanners/ec2/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.496.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "aws-scanners/ecs": {
@@ -6573,9 +7703,9 @@
       }
     },
     "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -6594,9 +7724,9 @@
       }
     },
     "node_modules/@npmcli/git": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.3.tgz",
-      "integrity": "sha512-UZp9NwK+AynTrKvHn5k3KviW/hA5eENmFsu3iAPe7sWRt0lFUdsY/wXIYjpDFe7cdSNwOIzbObfwgt6eL5/2zw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.4.tgz",
+      "integrity": "sha512-nr6/WezNzuYUppzXRaYu/W4aT5rLxdXqEFupbh6e/ovlYFQ8hpu1UUPV3Ir/YTl+74iXl2ZOMlGzudh9ZPUchQ==",
       "dev": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^7.0.0",
@@ -6622,9 +7752,9 @@
       }
     },
     "node_modules/@npmcli/git/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -6670,10 +7800,95 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/@npmcli/package-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.0.tgz",
+      "integrity": "sha512-OI2zdYBLhQ7kpNPaJxiflofYIpkNLi+lnGdzqUOfRmCF3r2l1nadcjtCYMJKv/Utm/ZtlffaUuTiAktPHbc17g==",
+      "dev": true,
+      "dependencies": {
+        "@npmcli/git": "^5.0.0",
+        "glob": "^10.2.2",
+        "hosted-git-info": "^7.0.0",
+        "json-parse-even-better-errors": "^3.0.0",
+        "normalize-package-data": "^6.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/hosted-git-info": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/json-parse-even-better-errors": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
+      "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/normalize-package-data": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
+      "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/@npmcli/promise-spawn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.0.tgz",
-      "integrity": "sha512-wBqcGsMELZna0jDblGd7UXgOby45TQaMWmbFwWX+SEotk4HV6zG2t6rT9siyLhPk4P6YYqgfL1UO8nMWDBVJXQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.1.tgz",
+      "integrity": "sha512-P4KkF9jX3y+7yFUxgcUdDtLy+t4OlDGuEBLNs57AZsfSfg+uV6MLndqGpnl4831ggaEdXwR50XFoZP4VFtHolg==",
       "dev": true,
       "dependencies": {
         "which": "^4.0.0"
@@ -6707,15 +7922,15 @@
       }
     },
     "node_modules/@npmcli/run-script": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-7.0.2.tgz",
-      "integrity": "sha512-Omu0rpA8WXvcGeY6DDzyRoY1i5DkCBkzyJ+m2u7PD6quzb0TvSqdIPOkTn8ZBOj7LbbcbMfZ3c5skwSu6m8y2w==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-7.0.4.tgz",
+      "integrity": "sha512-9ApYM/3+rBt9V80aYg6tZfzj3UWdiYyCt7gJUD1VJKvWF5nwKDSICXbYIQbspFTq6TOpbsEtIC0LArB8d9PFmg==",
       "dev": true,
       "dependencies": {
         "@npmcli/node-gyp": "^3.0.0",
+        "@npmcli/package-json": "^5.0.0",
         "@npmcli/promise-spawn": "^7.0.0",
         "node-gyp": "^10.0.0",
-        "read-package-json-fast": "^3.0.0",
         "which": "^4.0.0"
       },
       "engines": {
@@ -6768,13 +7983,22 @@
       }
     },
     "node_modules/@sigstore/bundle": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.1.0.tgz",
-      "integrity": "sha512-89uOo6yh/oxaU8AeOUnVrTdVMcGk9Q1hJa7Hkvalc6G3Z3CupWk4Xe9djSgJm9fMkH69s0P0cVHUoKSOemLdng==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.1.1.tgz",
+      "integrity": "sha512-v3/iS+1nufZdKQ5iAlQKcCsoh0jffQyABvYIxKsZQFWc4ubuGjwZklFHpDgV6O6T7vvV78SW5NHI91HFKEcxKg==",
       "dev": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.2.1"
       },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@sigstore/core": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-THobAPPZR9pDH2CAvDLpkrYedt7BlZnsyxDe+Isq4ZmGfPy5juOFZq487vCU2EgKD7aHSiTfE/i7sN7aEdzQnA==",
+      "dev": true,
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
@@ -6789,12 +8013,13 @@
       }
     },
     "node_modules/@sigstore/sign": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.2.0.tgz",
-      "integrity": "sha512-AAbmnEHDQv6CSfrWA5wXslGtzLPtAtHZleKOgxdQYvx/s76Fk6T6ZVt7w2IGV9j1UrFeBocTTQxaXG2oRrDhYA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.2.1.tgz",
+      "integrity": "sha512-U5sKQEj+faE1MsnLou1f4DQQHeFZay+V9s9768lw48J4pKykPj34rWyI1lsMOGJ3Mae47Ye6q3HAJvgXO21rkQ==",
       "dev": true,
       "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
         "@sigstore/protobuf-specs": "^0.2.1",
         "make-fetch-happen": "^13.0.0"
       },
@@ -6803,13 +8028,27 @@
       }
     },
     "node_modules/@sigstore/tuf": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-2.2.0.tgz",
-      "integrity": "sha512-KKATZ5orWfqd9ZG6MN8PtCIx4eevWSuGRKQvofnWXRpyMyUEpmrzg5M5BrCpjM+NfZ0RbNGOh5tCz/P2uoRqOA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-2.3.0.tgz",
+      "integrity": "sha512-S98jo9cpJwO1mtQ+2zY7bOdcYyfVYCUaofCG6wWRzk3pxKHVAkSfshkfecto2+LKsx7Ovtqbgb2LS8zTRhxJ9Q==",
       "dev": true,
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.2.1",
-        "tuf-js": "^2.1.0"
+        "tuf-js": "^2.2.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@sigstore/verify": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-0.1.0.tgz",
+      "integrity": "sha512-2UzMNYAa/uaz11NhvgRnIQf4gpLTJ59bhb8ESXaoSS5sxedfS+eLak8bsdMc+qpNQfITUTFoSKFx5h8umlRRiA==",
+      "dev": true,
+      "dependencies": {
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
+        "@sigstore/protobuf-specs": "^0.2.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -6860,11 +8099,11 @@
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
-      "integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+      "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -6889,14 +8128,33 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.16.tgz",
-      "integrity": "sha512-1k+FWHQDt2pfpXhJsOmNMmlAZ3NUQ98X5tYsjQhVGq+0X6cOBMhfh6Igd0IX3Ut6lEO6DQAdPMI/blNr3JZfMQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+      "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-tf+NIu9FkOh312b6M9G4D68is4Xr7qptzaZGZUREELF8ysE1yLKphqt7nsomjKZVwW7WE5pDDex9idowNGRQ/Q==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -6904,14 +8162,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.18.tgz",
-      "integrity": "sha512-QnPBi6D2zj6AHJdUTo5zXmk8vwHJ2bNevhcVned1y+TZz/OI5cizz5DsYNkqFUIDn8tBuEyKNgbmKVNhBbuY3g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+      "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -6919,13 +8177,13 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.12.tgz",
-      "integrity": "sha512-ZZQLzHBJkbiAAdj2C5K+lBlYp/XJ+eH2uy+jgJgYIFW/o5AM59Hlj7zyI44/ZTDIQWmBxb3EFv/c5t44V8/g8A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -6981,14 +8239,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.4.tgz",
-      "integrity": "sha512-gIPRFEGi+c6V52eauGKrjDzPWF2Cu7Z1r5F8A3j2wcwz25sPG/t8kjsbEhli/tS/2zJp/ybCZXe4j4ro3yv/HA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+      "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -7004,13 +8262,13 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.12.tgz",
-      "integrity": "sha512-fDZnTr5j9t5qcbeJ037aMZXxMka13Znqwrgy3PAqYj6Dm3XHXHftTH3q+NWgayUxl1992GFtQt1RuEzRMy3NnQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+      "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7031,18 +8289,18 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.12.tgz",
-      "integrity": "sha512-p5Y+iMHV3SoEpy3VSR7mifbreHQwVSvHSAz/m4GdoXfOzKzaYC8hYv10Ks7Deblkf7lhas8U+lAp9ThbBM+ZXA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+      "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7061,12 +8319,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.14.tgz",
-      "integrity": "sha512-poUNgKTw9XwPXfX9nEHpVgrMNVpaSMZbshqvPxFVoalF4wp6kRzYKOfdesSVectlQ51VtigoLfbXcdyPwvxgTg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+      "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7074,16 +8332,16 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.3.tgz",
-      "integrity": "sha512-ZrQ0/YX6hNVTxqMEHtEaDbDv6pNeEji/a5Vk3HuFC5R3ZY8lfoATyxmOGxBVYnF3NUvZLNC7umEv1WzWGWvCGQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+      "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.2.2",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7091,16 +8349,17 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.18.tgz",
-      "integrity": "sha512-VyrHQRldGSb3v9oFOB5yPxmLT7U2sQic2ytylOnYlnsmVOLlFIaI6sW22c+w2675yq+XZ6HOuzV7x2OBYCWRNA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+      "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "@smithy/util-retry": "^2.0.5",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -7109,11 +8368,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
-      "integrity": "sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+      "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7121,11 +8380,11 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
-      "integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+      "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7133,13 +8392,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.3.tgz",
-      "integrity": "sha512-J6lXvRHGVnSX3n1PYi+e1L5HN73DkkJpUviV3Ebf+8wSaIjAf+eVNbzyvh/S5EQz7nf4KVfwbD5vdoZMAthAEQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+      "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/shared-ini-file-loader": "^2.2.2",
-        "@smithy/types": "^2.4.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7147,14 +8406,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
-      "integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+      "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.12",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7162,11 +8421,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
-      "integrity": "sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+      "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7174,11 +8433,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+      "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7186,12 +8445,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
-      "integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+      "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-uri-escape": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7199,11 +8458,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
-      "integrity": "sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+      "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7211,22 +8470,22 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.5.tgz",
-      "integrity": "sha512-M0SeJnEgD2ywJyV99Fb1yKFzmxDe9JfpJiYTVSRMyRLc467BPU0qsuuDPzMCdB1mU8M8u1rVOdkqdoyFN8UFTw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0"
+        "@smithy/types": "^2.9.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.2.tgz",
-      "integrity": "sha512-noyQUPn7b1M8uB0GEXc/Zyxq+5K2b7aaqWnLp+hgJ7+xu/FCvtyWy5eWLDjQEsHnAet2IZhS5QF8872OR69uNg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7234,17 +8493,17 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.12.tgz",
-      "integrity": "sha512-6Kc2lCZEVmb1nNYngyNbWpq0d82OZwITH11SW/Q0U6PX5fH7B2cIcFe7o6eGEFPkTZTP8itTzmYiGcECL0D0Lw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.12",
-        "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/eventstream-codec": "^2.1.1",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7252,13 +8511,15 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.12.tgz",
-      "integrity": "sha512-XXqhridfkKnpj+lt8vM6HRlZbqUAqBjVC74JIi13F/AYQd/zTj9SOyGfxnbp4mjY9q28LityxIuV8CTinr9r5w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+      "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
       "dependencies": {
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-stream": "^2.0.17",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7266,9 +8527,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7277,21 +8538,21 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.12.tgz",
-      "integrity": "sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+      "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/querystring-parser": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
-      "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+      "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7299,17 +8560,17 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+      "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
       "dependencies": {
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+      "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7318,11 +8579,11 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/is-array-buffer": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7330,9 +8591,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+      "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7341,13 +8602,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.16.tgz",
-      "integrity": "sha512-Uv5Cu8nVkuvLn0puX+R9zWbSNpLIR3AxUlPoLJ7hC5lvir8B2WVqVEkJLwtixKAncVLasnTVjPDCidtAUTGEQw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+      "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -7356,26 +8617,40 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.21.tgz",
-      "integrity": "sha512-cUEsttVZ79B7Al2rWK2FW03HBpD9LyuqFtm+1qFty5u9sHSdesr215gS2Ln53fTopNiPgeXpdoM3IgjvIO0rJw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.1.1.tgz",
+      "integrity": "sha512-tYVrc+w+jSBfBd267KDnvSGOh4NMz+wVH7v4CClDbkdPfnjvImBZsOURncT5jsFwR9KCuDyPoSZq4Pa6+eCUrA==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/credential-provider-imds": "^2.0.18",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+      "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
+      "dev": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7384,11 +8659,11 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7396,12 +8671,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.5.tgz",
-      "integrity": "sha512-x3t1+MQAJ6QONk3GTbJNcugCFDVJ+Bkro5YqQQK1EyVesajNDqxFtCx9WdOFNGm/Cbm7tUdwVEmfKQOJoU2Vtw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7409,17 +8684,17 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.17.tgz",
-      "integrity": "sha512-fP/ZQ27rRvHsqItds8yB7jerwMpZFTL3QqbQbidUiG0+mttMoKdP0ZqnvM8UK5q0/dfc3/pN7g4XKPXOU7oRWw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+      "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7547,9 +8822,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -7558,11 +8833,11 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -7583,9 +8858,9 @@
       }
     },
     "node_modules/@tapjs/after": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/after/-/after-1.1.16.tgz",
-      "integrity": "sha512-/KwElRYMMN4pKDP0VT1a5d9RLsnV/HrnpvBbDJiavs816wQOEOwMt1q4rXVU2XO6cSpXn0cm77xBLDkkBlJQWA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/after/-/after-1.1.18.tgz",
+      "integrity": "sha512-r0vMFMfxmO6UR+pB9zGvamaeUI+yhLokYAagsKoM3JdoZgyq0iw1fHn5hPPY8AC1tAzEYG3KtVDpJfpoOr67Iw==",
       "dev": true,
       "dependencies": {
         "is-actual-promise": "^1.0.0"
@@ -7594,13 +8869,13 @@
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/after-each": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/after-each/-/after-each-1.1.16.tgz",
-      "integrity": "sha512-TlhGKfX+3GHwqGhMxNWZ50xb8vfwp2+kx0COTbuGLrwcCgwmpFPU/r/7td03BOtdCV2J1yKFxGiRDvZyowZLyg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/after-each/-/after-each-1.1.18.tgz",
+      "integrity": "sha512-AuXeD8uUYQ/CUdfhx2jvBhJf3M+T/Kroz5T6ItocZ3jf8H/4x2OKMVbb5YcB7J4ANGtmzXp+8SBseoN1av6y0Q==",
       "dev": true,
       "dependencies": {
         "function-loop": "^4.0.0"
@@ -7609,18 +8884,18 @@
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/asserts": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/asserts/-/asserts-1.1.16.tgz",
-      "integrity": "sha512-gf37N6VMv7iuaomB8Yr+3VyuPS77kXy6Uw2n2AHsiU47Q0eNodjrN0d2G+glfrXfD3zLbsLuQHx4x6IsAsgq7Q==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/asserts/-/asserts-1.1.18.tgz",
+      "integrity": "sha512-MwGs/QklLRAsMnB4fO6QFaZ0myR//E21Rek/gGCpTxz7eUwCh24/y7MlBV0W6zDFdnQ1GFbHc/fIBVtcPAWjyw==",
       "dev": true,
       "dependencies": {
         "@tapjs/stack": "1.2.7",
         "is-actual-promise": "^1.0.0",
-        "tcompare": "6.4.4",
+        "tcompare": "6.4.5",
         "trivial-deferred": "^2.0.0"
       },
       "engines": {
@@ -7630,13 +8905,13 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/before": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/before/-/before-1.1.16.tgz",
-      "integrity": "sha512-3hO7eQbL1Ac8OgPq9+nBuQS4cz/eVGcaPDs0cTcTy3NYbhCrp4MGTpRtKxF4Cds1Y/rHAipB81MhZrmG7xBjlg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/before/-/before-1.1.18.tgz",
+      "integrity": "sha512-2rkXrAWlkl0+bZ8wSNfEW/7TANs/Dg5SrY2MmdEb0x7Q/zbMoGjrPVKDRF20Me0p+tJBLWSY+FXQ0OhXK0pUjg==",
       "dev": true,
       "dependencies": {
         "is-actual-promise": "^1.0.0"
@@ -7645,13 +8920,13 @@
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/before-each": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/before-each/-/before-each-1.1.16.tgz",
-      "integrity": "sha512-yJAt0yGOQFnozmm2fQSfAELp/hMzudYOr4udANZ/1RIVJYXHThj0qrUZP9nEkXMWK4wRQytOInt1jEwXR/cFfQ==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/before-each/-/before-each-1.1.18.tgz",
+      "integrity": "sha512-qxBQaOY+IkThP9iauL1tHCxirG9XuKGJvGHY4IGKuk0RswWkXmawSe5hcJ8m569dRXy9yJHEV7N0QueuyWxpBA==",
       "dev": true,
       "dependencies": {
         "function-loop": "^4.0.0"
@@ -7660,17 +8935,17 @@
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/config": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@tapjs/config/-/config-2.4.12.tgz",
-      "integrity": "sha512-7l7dqKuYXm9zNj7c1QFoWqYxOtshP69KyU3q4vSh8xJmTzz19miZbfx881f8SIb3/PtDqTilv1CFxEaKuZgmEw==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@tapjs/config/-/config-2.4.15.tgz",
+      "integrity": "sha512-uU/gfQJh8aSokEBgwAAHD5ctHYbIiZYFaL6IrROcDp7Wr7/fd/dn9K4efpREwKpqKqOgL3XZPOwx7prKxrLHhA==",
       "dev": true,
       "dependencies": {
-        "@tapjs/core": "1.4.5",
-        "@tapjs/test": "1.3.16",
+        "@tapjs/core": "1.5.0",
+        "@tapjs/test": "1.4.0",
         "chalk": "^5.2.0",
         "jackspeak": "^2.3.6",
         "polite-json": "^4.0.1",
@@ -7684,8 +8959,8 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5",
-        "@tapjs/test": "1.3.16"
+        "@tapjs/core": "1.5.0",
+        "@tapjs/test": "1.4.0"
       }
     },
     "node_modules/@tapjs/config/node_modules/chalk": {
@@ -7701,14 +8976,14 @@
       }
     },
     "node_modules/@tapjs/core": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@tapjs/core/-/core-1.4.5.tgz",
-      "integrity": "sha512-vvLrM75t1/Yq2MlH1x3jfJPdPs4ArR+tFTpzNgQ+PF50x0PTDup1sVj7ZhZbNY4zeQFsvnVtoReptr3FsMix7Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-g+NNI5TGXVJR5G4AZCU0hWu1pdA2qB2OYrY9Ej3mWeg97mvNZBVgNtvx8Vjdwp9BfgbJfyFK7PvoB4nhKgetSQ==",
       "dev": true,
       "dependencies": {
         "@tapjs/processinfo": "^3.1.6",
         "@tapjs/stack": "1.2.7",
-        "@tapjs/test": "1.3.16",
+        "@tapjs/test": "1.4.0",
         "async-hook-domain": "^4.0.1",
         "diff": "^5.1.0",
         "is-actual-promise": "^1.0.0",
@@ -7716,7 +8991,7 @@
         "signal-exit": "4.1",
         "tap-parser": "15.3.1",
         "tap-yaml": "2.2.1",
-        "tcompare": "6.4.4",
+        "tcompare": "6.4.5",
         "trivial-deferred": "^2.0.0"
       },
       "engines": {
@@ -7751,9 +9026,9 @@
       }
     },
     "node_modules/@tapjs/filter": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/filter/-/filter-1.2.16.tgz",
-      "integrity": "sha512-TiOjFMy+Sg5Lnm5pzUcjgpyw19bEg0WejLGpml0DPQi/OEVYlazu2lcDQFRgpRBhvYlOc7we9nul2y2a3Jh8PQ==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/filter/-/filter-1.2.18.tgz",
+      "integrity": "sha512-0yCqaHYLejI/KyxdB5EsrRVu3wxZVl7vPXTwBoyc+ycJWXPapHLhKl67Xk5x3FW/nNelA9TCq/tSHcYlogGN0g==",
       "dev": true,
       "engines": {
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
@@ -7762,13 +9037,13 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/fixture": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/fixture/-/fixture-1.2.16.tgz",
-      "integrity": "sha512-9+QUkGW4CoSR4cKO3vLe9YYsBgD9wCRvta5jxquTWk9VJiVQZ3pKIqaSULB47kUZbtERorhvI7J5YCYWnVbF7A==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/fixture/-/fixture-1.2.18.tgz",
+      "integrity": "sha512-BQIRxydaqjZIG61QhoiQOc9HE3MxSjCn7SUsIfYCzoZoY+3aY6iCdTVg2la86b5ikTbwoWxWWbqICnFWebuHnQ==",
       "dev": true,
       "dependencies": {
         "mkdirp": "^3.0.0",
@@ -7781,7 +9056,7 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/fixture/node_modules/glob": {
@@ -7840,28 +9115,28 @@
       }
     },
     "node_modules/@tapjs/intercept": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/intercept/-/intercept-1.2.16.tgz",
-      "integrity": "sha512-Mgw3ib7bu2cFjbeujFw6y7CcEq1mNd/EQhrg1L9Q96bETtp9YNSlox4Z7MKmTEtnk9fzuCIVs7T9QbI8eq2k7w==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/intercept/-/intercept-1.2.18.tgz",
+      "integrity": "sha512-Trcmp64RKD2/nMz7/+NuwjJHfrn8eFofX3s3g0+QGvnTv+5B5ZQs+zWjS7q2d1Qt8LDV8CfS5w3BhYyONsocSw==",
       "dev": true,
       "dependencies": {
-        "@tapjs/after": "1.1.16",
+        "@tapjs/after": "1.1.18",
         "@tapjs/stack": "1.2.7"
       },
       "engines": {
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/mock": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@tapjs/mock/-/mock-1.2.14.tgz",
-      "integrity": "sha512-HnXUmkn3xk4gzoMb3s77EK2CJaBzAoi1hzyyE6abBJf8dnLCid4xUOs+H4KybWllKcwwIUr0yzKmXJl7eCWVbQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/mock/-/mock-1.3.0.tgz",
+      "integrity": "sha512-Uzyikl8SS8Mg7OOr2HuyiaVhYvHNRZnw6A1/qTiJnoZ1MHcLFuwFqIX9ZhfXMil5MIYC/ET096VMDm45q9Tdvw==",
       "dev": true,
       "dependencies": {
-        "@tapjs/after": "1.1.16",
+        "@tapjs/after": "1.1.18",
         "@tapjs/stack": "1.2.7",
         "resolve-import": "^1.4.5",
         "walk-up-path": "^3.0.1"
@@ -7873,13 +9148,13 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/node-serialize": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@tapjs/node-serialize/-/node-serialize-1.2.5.tgz",
-      "integrity": "sha512-y7QS5Sev6QQ0O+sx5WjY11XoUBzuNdSNDwVRxrj1qwTuigRVj+1ePWutP80pn7bE/r2G+2L2IHuEsMDRLCgulw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/node-serialize/-/node-serialize-1.3.0.tgz",
+      "integrity": "sha512-52oQKQJMMKrI1cNu8kJ5WTv8YFnbhwfwUs3Jh1vXQb4tOhLW8IHWqXBi5AiNL3HlCMMHaKDFQjW6sbbJuMyJPA==",
       "dev": true,
       "dependencies": {
         "@tapjs/error-serdes": "1.2.1",
@@ -7893,7 +9168,7 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/processinfo": {
@@ -7924,12 +9199,12 @@
       }
     },
     "node_modules/@tapjs/reporter": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@tapjs/reporter/-/reporter-1.3.13.tgz",
-      "integrity": "sha512-yiEPF1NfcD5RaosIFq3wqT05/3S3caHEY+eG6MwH+xmZSO0Fv7Q/t9qXoWfuQOyMiIARjhKQfGdqHYXbC50f+Q==",
+      "version": "1.3.16",
+      "resolved": "https://registry.npmjs.org/@tapjs/reporter/-/reporter-1.3.16.tgz",
+      "integrity": "sha512-YoZpBAFGdZyrhIaRCZDuWSeCc10A3YG/4mIdPsKpSbLXPBZ1hwCV8Y/LPCpH5kunZTXYocvQoRHU+oD4pLXC3g==",
       "dev": true,
       "dependencies": {
-        "@tapjs/config": "2.4.12",
+        "@tapjs/config": "2.4.15",
         "@tapjs/stack": "1.2.7",
         "chalk": "^5.2.0",
         "ink": "^4.4.1",
@@ -7941,7 +9216,7 @@
         "string-length": "^6.0.0",
         "tap-parser": "15.3.1",
         "tap-yaml": "2.2.1",
-        "tcompare": "6.4.4"
+        "tcompare": "6.4.5"
       },
       "engines": {
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
@@ -7950,7 +9225,7 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/reporter/node_modules/chalk": {
@@ -7972,19 +9247,19 @@
       "dev": true
     },
     "node_modules/@tapjs/run": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@tapjs/run/-/run-1.4.14.tgz",
-      "integrity": "sha512-jkOMWlxAUTjPtJqLWHVAbH4hkaj/oAf6W20rA+gRhxZQ7VtAgEgVavV3lSaNM3gPmgZwiJZezX+hHO3nDkCfrg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/run/-/run-1.5.0.tgz",
+      "integrity": "sha512-WrmbHHrhvRvLlTTAGiogF09xiPoorsoG4diAIKifGUyGD/9qRA7pT2mzYIqXvhyxbtuEmaeobHjupSZrak+O4Q==",
       "dev": true,
       "dependencies": {
-        "@tapjs/after": "1.1.16",
-        "@tapjs/before": "1.1.16",
-        "@tapjs/config": "2.4.12",
+        "@tapjs/after": "1.1.18",
+        "@tapjs/before": "1.1.18",
+        "@tapjs/config": "2.4.15",
         "@tapjs/processinfo": "^3.1.6",
-        "@tapjs/reporter": "1.3.13",
-        "@tapjs/spawn": "1.1.16",
-        "@tapjs/stdin": "1.1.16",
-        "@tapjs/test": "1.3.16",
+        "@tapjs/reporter": "1.3.16",
+        "@tapjs/spawn": "1.1.18",
+        "@tapjs/stdin": "1.1.18",
+        "@tapjs/test": "1.4.0",
         "c8": "^8.0.1",
         "chalk": "^5.3.0",
         "chokidar": "^3.5.3",
@@ -8000,7 +9275,7 @@
         "signal-exit": "^4.1.0",
         "tap-parser": "15.3.1",
         "tap-yaml": "2.2.1",
-        "tcompare": "6.4.4",
+        "tcompare": "6.4.5",
         "trivial-deferred": "^2.0.0",
         "which": "^4.0.0"
       },
@@ -8014,7 +9289,7 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/run/node_modules/chalk": {
@@ -8121,13 +9396,13 @@
       }
     },
     "node_modules/@tapjs/snapshot": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/snapshot/-/snapshot-1.2.16.tgz",
-      "integrity": "sha512-4Da9TXAQ3ni+JC8AfzDKRQG6cIjT/LxTTGmVDK4/Fe4NubdNKw/A76Gvl9xPUIlqW1vNZVGVN/0KruEDKJ4xkQ==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/snapshot/-/snapshot-1.2.18.tgz",
+      "integrity": "sha512-fHt4ZgutJ922/YdmXN2d6dkwFTR6KsyD02jcSYBXVDGdFC2YnsjKk/o9s3Yt9tYnYES6Et+6udPlAKcakzR5jQ==",
       "dev": true,
       "dependencies": {
         "is-actual-promise": "^1.0.0",
-        "tcompare": "6.4.4",
+        "tcompare": "6.4.5",
         "trivial-deferred": "^2.0.0"
       },
       "engines": {
@@ -8137,19 +9412,19 @@
         "url": "https://github.com/sponsors/isaacs"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/spawn": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/spawn/-/spawn-1.1.16.tgz",
-      "integrity": "sha512-Y0/WNlFp8kkRwKNyOqYUrIwwY2sLkegakvhtcJsg9eg/P4CC9lnh+zaSEfgNGJb24S4qeWOOnJ/rQ68bK9HVYg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/spawn/-/spawn-1.1.18.tgz",
+      "integrity": "sha512-E5H0NTyTZ0FnkPUd5JU3c2KrnjjMDDAuctRd2b0v/M5LB+uAlwwEEJJ6rh+dBsFK/yatfgPli+nbHZVjUz+Usw==",
       "dev": true,
       "engines": {
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/stack": {
@@ -8165,39 +9440,39 @@
       }
     },
     "node_modules/@tapjs/stdin": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/stdin/-/stdin-1.1.16.tgz",
-      "integrity": "sha512-kP22n5kaoMcAp+elESvRCg/fodfeefsbtacTOGAfXnHLK+eh8XBSz1SwDmyaeQ4/C3F6SMQ8+8ZeybMcbeLEGQ==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/stdin/-/stdin-1.1.18.tgz",
+      "integrity": "sha512-UyhK8bRRhQkmBb7N/NFa/11DucHfIzCyyba7uax+dkuXSd6OccTZVxLpRMuaOUV59QCCFAJUJDQnmaWj35fI7Q==",
       "dev": true,
       "engines": {
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/test": {
-      "version": "1.3.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/test/-/test-1.3.16.tgz",
-      "integrity": "sha512-HalYruL4tpTgKVJQwkTh/vw5Mt7sEVXXoS7bTik8tyPr9wQ7UXTRPB2EErna89mhhRc0hYU4NYXlwzS1UHiQkQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/test/-/test-1.4.0.tgz",
+      "integrity": "sha512-t4U11uAUDUeBQTdlqtiDoiuiG3lKLhHa+PxrdIR3GlG+2wDcpqFR8aFFiuq3XTvks0uoWjKx3WkAMyjNsxmikg==",
       "dev": true,
       "dependencies": {
         "@isaacs/ts-node-temp-fork-for-pr-2009": "^10.9.5",
-        "@tapjs/after": "1.1.16",
-        "@tapjs/after-each": "1.1.16",
-        "@tapjs/asserts": "1.1.16",
-        "@tapjs/before": "1.1.16",
-        "@tapjs/before-each": "1.1.16",
-        "@tapjs/filter": "1.2.16",
-        "@tapjs/fixture": "1.2.16",
-        "@tapjs/intercept": "1.2.16",
-        "@tapjs/mock": "1.2.14",
-        "@tapjs/node-serialize": "1.2.5",
-        "@tapjs/snapshot": "1.2.16",
-        "@tapjs/spawn": "1.1.16",
-        "@tapjs/stdin": "1.1.16",
-        "@tapjs/typescript": "1.3.5",
-        "@tapjs/worker": "1.1.16",
+        "@tapjs/after": "1.1.18",
+        "@tapjs/after-each": "1.1.18",
+        "@tapjs/asserts": "1.1.18",
+        "@tapjs/before": "1.1.18",
+        "@tapjs/before-each": "1.1.18",
+        "@tapjs/filter": "1.2.18",
+        "@tapjs/fixture": "1.2.18",
+        "@tapjs/intercept": "1.2.18",
+        "@tapjs/mock": "1.3.0",
+        "@tapjs/node-serialize": "1.3.0",
+        "@tapjs/snapshot": "1.2.18",
+        "@tapjs/spawn": "1.1.18",
+        "@tapjs/stdin": "1.1.18",
+        "@tapjs/typescript": "1.4.0",
+        "@tapjs/worker": "1.1.18",
         "glob": "^10.3.10",
         "jackspeak": "^2.3.6",
         "mkdirp": "^3.0.0",
@@ -8215,7 +9490,7 @@
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/test/node_modules/glob": {
@@ -8287,9 +9562,9 @@
       }
     },
     "node_modules/@tapjs/typescript": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@tapjs/typescript/-/typescript-1.3.5.tgz",
-      "integrity": "sha512-LoOHEJ1Bx3MWnh4+uIBXVobxkYNwFzJVnzl1tsLuX0jgGBIGtvmFwXDoM9MtcmO5m8WMZL9bMDT1NWPtcO0V6w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/typescript/-/typescript-1.4.0.tgz",
+      "integrity": "sha512-3b3pNI20Cf9NRMuT6GE288RESMYMcrwrKuj29Mroiy9MkLEyyPPHqeSRstvakn9/i/nhTlXj2YIftPo80H3OlQ==",
       "dev": true,
       "dependencies": {
         "@isaacs/ts-node-temp-fork-for-pr-2009": "^10.9.5"
@@ -8298,19 +9573,19 @@
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tapjs/worker": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/worker/-/worker-1.1.16.tgz",
-      "integrity": "sha512-BVXyGnf3PMJ7hnwIgaheSpLESI8E9d95EBi8Ni/L3sObbxYR3xIPnhiwCEUCQOp6pkeo8z04T7nJdbQW3dslIA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/worker/-/worker-1.1.18.tgz",
+      "integrity": "sha512-wxl/dXByMWk9FuYiiSzY/U5QU0oe9EWpf7pJ48feWsTTn42wihUHZT25kbleR4V2l68/SlTPlJkEsKnHjU27Pg==",
       "dev": true,
       "engines": {
         "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
       },
       "peerDependencies": {
-        "@tapjs/core": "1.4.5"
+        "@tapjs/core": "1.5.0"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -9478,9 +10753,9 @@
       }
     },
     "node_modules/cacache": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.0.tgz",
-      "integrity": "sha512-I7mVOPl3PUCeRub1U8YoGz2Lqv9WOBpobZ8RyWFXmReuILz+3OAyTa5oH3QPdtKZD7N0Yk00aLfzn0qvp8dZ1w==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.2.tgz",
+      "integrity": "sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==",
       "dev": true,
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
@@ -9488,7 +10763,7 @@
         "glob": "^10.2.2",
         "lru-cache": "^10.0.1",
         "minipass": "^7.0.3",
-        "minipass-collect": "^1.0.2",
+        "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^4.0.0",
@@ -9523,9 +10798,9 @@
       }
     },
     "node_modules/cacache/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -12046,9 +13321,9 @@
       }
     },
     "node_modules/ignore-walk": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.3.tgz",
-      "integrity": "sha512-C7FfFoTA+bI10qfeydT8aZbvr91vAEU+2W5BZUlzPec47oNb07SsOfwYrtxuvOYdUApPP/Qlh4DtAO51Ekk2QA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.4.tgz",
+      "integrity": "sha512-t7sv42WkwFkyKbivUCglsQW5YWMskWtbEf4MNKX5u/CCWHKSPzN4FtBQGsQZgCLbxOzpVlcbWVK5KB3auIOjSw==",
       "dev": true,
       "dependencies": {
         "minimatch": "^9.0.0"
@@ -12918,9 +14193,9 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.1.tgz",
-      "integrity": "sha512-opCrKqbthmq3SKZ10mFMQG9dk3fTa3quaOLD35kJa5ejwZHd9xAr+kLuziiZz2cG32s4lMZxNdmdcEQnTDP4+g==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -13562,27 +14837,15 @@
       }
     },
     "node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
       "dev": true,
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.0.3"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-collect/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minipass-fetch": {
@@ -14227,21 +15490,21 @@
       }
     },
     "node_modules/npm-package-arg/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
       }
     },
     "node_modules/npm-packlist": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.0.tgz",
-      "integrity": "sha512-ErAGFB5kJUciPy1mmx/C2YFbvxoJ0QJ9uwkCZOeR6CqLLISPZBOiFModAbSXnjjlwW5lOhuhXva+fURsSGJqyw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.2.tgz",
+      "integrity": "sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==",
       "dev": true,
       "dependencies": {
-        "ignore-walk": "^6.0.0"
+        "ignore-walk": "^6.0.4"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -14660,9 +15923,9 @@
       }
     },
     "node_modules/pacote": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-17.0.4.tgz",
-      "integrity": "sha512-eGdLHrV/g5b5MtD5cTPyss+JxOlaOloSMG3UwPMAvL8ywaLJ6beONPF40K4KKl/UI6q5hTKCJq5rCu8tkF+7Dg==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-17.0.6.tgz",
+      "integrity": "sha512-cJKrW21VRE8vVTRskJo78c/RCvwJCn1f4qgfxL4w77SOWrTCRcmfkYHlHtS0gqpgjv3zhXflRtgsrUCX5xwNnQ==",
       "dev": true,
       "dependencies": {
         "@npmcli/git": "^5.0.0",
@@ -14680,7 +15943,7 @@
         "promise-retry": "^2.0.1",
         "read-package-json": "^7.0.0",
         "read-package-json-fast": "^3.0.0",
-        "sigstore": "^2.0.0",
+        "sigstore": "^2.2.0",
         "ssri": "^10.0.0",
         "tar": "^6.1.11"
       },
@@ -14804,9 +16067,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -15304,9 +16567,9 @@
       }
     },
     "node_modules/read-package-json-fast/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
-      "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
+      "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -15347,18 +16610,18 @@
       }
     },
     "node_modules/read-package-json/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
-      "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
+      "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
       "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/read-package-json/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -15899,15 +17162,17 @@
       "dev": true
     },
     "node_modules/sigstore": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.1.0.tgz",
-      "integrity": "sha512-kPIj+ZLkyI3QaM0qX8V/nSsweYND3W448pwkDgS6CQ74MfhEkIR8ToK5Iyx46KJYRjseVcD3Rp9zAmUAj6ZjPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.2.0.tgz",
+      "integrity": "sha512-fcU9clHwEss2/M/11FFM8Jwc4PjBgbhXoNskoK5guoK0qGQBSeUbQZRJ+B2fDFIvhyf0gqCaPrel9mszbhAxug==",
       "dev": true,
       "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
         "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/sign": "^2.1.0",
-        "@sigstore/tuf": "^2.1.0"
+        "@sigstore/sign": "^2.2.1",
+        "@sigstore/tuf": "^2.3.0",
+        "@sigstore/verify": "^0.1.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -16667,29 +17932,29 @@
       }
     },
     "node_modules/tap": {
-      "version": "18.5.7",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-18.5.7.tgz",
-      "integrity": "sha512-H2QstHSCmEQAriaPZw5j5DzfASpf15fPVn3a2Vc2TxJ0sahTJo5L7KIihInO6MsrEwGHpQU53u1lB7u8F6QZwg==",
+      "version": "18.7.0",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-18.7.0.tgz",
+      "integrity": "sha512-bL/0krlx8k3fY9mjI9CMfVoAGclZegl+vm5pEJpF/USxam5eNhp5wLk5UH0ST3gWEJkW0PDdFHTOStE+mYurrQ==",
       "dev": true,
       "dependencies": {
-        "@tapjs/after": "1.1.16",
-        "@tapjs/after-each": "1.1.16",
-        "@tapjs/asserts": "1.1.16",
-        "@tapjs/before": "1.1.16",
-        "@tapjs/before-each": "1.1.16",
-        "@tapjs/core": "1.4.5",
-        "@tapjs/filter": "1.2.16",
-        "@tapjs/fixture": "1.2.16",
-        "@tapjs/intercept": "1.2.16",
-        "@tapjs/mock": "1.2.14",
-        "@tapjs/node-serialize": "1.2.5",
-        "@tapjs/run": "1.4.14",
-        "@tapjs/snapshot": "1.2.16",
-        "@tapjs/spawn": "1.1.16",
-        "@tapjs/stdin": "1.1.16",
-        "@tapjs/test": "1.3.16",
-        "@tapjs/typescript": "1.3.5",
-        "@tapjs/worker": "1.1.16",
+        "@tapjs/after": "1.1.18",
+        "@tapjs/after-each": "1.1.18",
+        "@tapjs/asserts": "1.1.18",
+        "@tapjs/before": "1.1.18",
+        "@tapjs/before-each": "1.1.18",
+        "@tapjs/core": "1.5.0",
+        "@tapjs/filter": "1.2.18",
+        "@tapjs/fixture": "1.2.18",
+        "@tapjs/intercept": "1.2.18",
+        "@tapjs/mock": "1.3.0",
+        "@tapjs/node-serialize": "1.3.0",
+        "@tapjs/run": "1.5.0",
+        "@tapjs/snapshot": "1.2.18",
+        "@tapjs/spawn": "1.1.18",
+        "@tapjs/stdin": "1.1.18",
+        "@tapjs/test": "1.4.0",
+        "@tapjs/typescript": "1.4.0",
+        "@tapjs/worker": "1.1.18",
         "resolve-import": "^1.4.5"
       },
       "bin": {
@@ -16794,9 +18059,9 @@
       }
     },
     "node_modules/tcompare": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-6.4.4.tgz",
-      "integrity": "sha512-mvv9apveoY+XFP2CO2xF3Mkz/v+itzV9ZlhcDY+chIpFGYeTEgiCYdFUPynPme82kNU7UweuxDBQ5J6FkVox/Q==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-6.4.5.tgz",
+      "integrity": "sha512-Whuz9xlKKI2XXICKDSDRKjXdBuC6gBNOgmEUtH7UFyQeYzfUMQ19DyjZULarGKDGFhgOg3CJ+IQUEfpkOPg0Uw==",
       "dev": true,
       "dependencies": {
         "diff": "^5.1.0",
@@ -17060,9 +18325,9 @@
       }
     },
     "node_modules/tshy": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tshy/-/tshy-1.8.0.tgz",
-      "integrity": "sha512-Lg2hVO+B8pdNYvBUSgcra4ULlFCcBIkd7ZJ3nRIPvEjplgEscNSwnOzpIMzKW1m17AYhEGcy1nzv7mA3fi/oEQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/tshy/-/tshy-1.11.0.tgz",
+      "integrity": "sha512-5T5PVyuYQKTcOKz5a2lpwx4WKi8yEzQGO0Q5l+9clJMYupMaTI7ONEwKggGAZDQQGIgCOyUCfBWnSkG0XdJc+A==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.3.0",
@@ -17072,7 +18337,7 @@
         "resolve-import": "^1.4.4",
         "rimraf": "^5.0.1",
         "sync-content": "^1.0.2",
-        "typescript": "5.2",
+        "typescript": "5.2 || 5.3",
         "walk-up-path": "^3.0.1"
       },
       "bin": {
@@ -17150,9 +18415,9 @@
       }
     },
     "node_modules/tshy/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -17337,9 +18602,9 @@
       }
     },
     "node_modules/tuf-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.1.0.tgz",
-      "integrity": "sha512-eD7YPPjVlMzdggrOeE8zwoegUaG/rt6Bt3jwoQPunRiNVzgcCE009UDFJKJjG+Gk9wFu6W/Vi+P5d/5QpdD9jA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.2.0.tgz",
+      "integrity": "sha512-ZSDngmP1z6zw+FIkIBjvOp/II/mIub/O7Pp12j1WNsiCpg5R5wAc//i555bBQsE44O94btLt0xM/Zr2LQjwdCg==",
       "dev": true,
       "dependencies": {
         "@tufjs/models": "2.0.0",
@@ -17695,9 +18960,9 @@
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
-      "integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -17709,9 +18974,9 @@
       }
     },
     "node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -18082,9 +19347,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -22773,14 +24038,257 @@
       "version": "file:aws-scanners/ec2",
       "requires": {
         "@aws-sdk/client-ec2": "3.428.0",
+        "@aws-sdk/credential-providers": "^3.501.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
+        "@infrascan/fs-connector": "^0.2.3",
         "@infrascan/shared-types": "^0.2.4",
         "aws-sdk-client-mock": "^3.0.1",
         "eslint-config-codegen": "^1.0.0",
+        "tap": "^18.7.0",
         "tsconfig": "^0.0.0"
       },
       "dependencies": {
+        "@aws-sdk/client-cognito-identity": {
+          "version": "3.501.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.501.0.tgz",
+          "integrity": "sha512-ynWW9VVT7CTMQBh8l7WFt2SNekg3667gwjQmeGN8+DDMDqt2Z+L52717S0AN1pQDUMbh/DuKKPk+Sr30HBK3vA==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/client-sts": "3.501.0",
+            "@aws-sdk/core": "3.496.0",
+            "@aws-sdk/credential-provider-node": "3.501.0",
+            "@aws-sdk/middleware-host-header": "3.496.0",
+            "@aws-sdk/middleware-logger": "3.496.0",
+            "@aws-sdk/middleware-recursion-detection": "3.496.0",
+            "@aws-sdk/middleware-signing": "3.496.0",
+            "@aws-sdk/middleware-user-agent": "3.496.0",
+            "@aws-sdk/region-config-resolver": "3.496.0",
+            "@aws-sdk/types": "3.496.0",
+            "@aws-sdk/util-endpoints": "3.496.0",
+            "@aws-sdk/util-user-agent-browser": "3.496.0",
+            "@aws-sdk/util-user-agent-node": "3.496.0",
+            "@smithy/config-resolver": "^2.1.1",
+            "@smithy/core": "^1.3.1",
+            "@smithy/fetch-http-handler": "^2.4.1",
+            "@smithy/hash-node": "^2.1.1",
+            "@smithy/invalid-dependency": "^2.1.1",
+            "@smithy/middleware-content-length": "^2.1.1",
+            "@smithy/middleware-endpoint": "^2.4.1",
+            "@smithy/middleware-retry": "^2.1.1",
+            "@smithy/middleware-serde": "^2.1.1",
+            "@smithy/middleware-stack": "^2.1.1",
+            "@smithy/node-config-provider": "^2.2.1",
+            "@smithy/node-http-handler": "^2.3.1",
+            "@smithy/protocol-http": "^3.1.1",
+            "@smithy/smithy-client": "^2.3.1",
+            "@smithy/types": "^2.9.1",
+            "@smithy/url-parser": "^2.1.1",
+            "@smithy/util-base64": "^2.1.1",
+            "@smithy/util-body-length-browser": "^2.1.1",
+            "@smithy/util-body-length-node": "^2.2.1",
+            "@smithy/util-defaults-mode-browser": "^2.1.1",
+            "@smithy/util-defaults-mode-node": "^2.1.1",
+            "@smithy/util-endpoints": "^1.1.1",
+            "@smithy/util-retry": "^2.1.1",
+            "@smithy/util-utf8": "^2.1.1",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@aws-sdk/client-sts": {
+              "version": "3.501.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.501.0.tgz",
+              "integrity": "sha512-Uwc/xuxsA46dZS5s+4U703LBNDrGpWF7RB4XYEEMD21BLfGuqntxLLQux8xxKt3Pcur0CsXNja5jXt3uLnE5MA==",
+              "dev": true,
+              "requires": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/core": "3.496.0",
+                "@aws-sdk/credential-provider-node": "3.501.0",
+                "@aws-sdk/middleware-host-header": "3.496.0",
+                "@aws-sdk/middleware-logger": "3.496.0",
+                "@aws-sdk/middleware-recursion-detection": "3.496.0",
+                "@aws-sdk/middleware-user-agent": "3.496.0",
+                "@aws-sdk/region-config-resolver": "3.496.0",
+                "@aws-sdk/types": "3.496.0",
+                "@aws-sdk/util-endpoints": "3.496.0",
+                "@aws-sdk/util-user-agent-browser": "3.496.0",
+                "@aws-sdk/util-user-agent-node": "3.496.0",
+                "@smithy/config-resolver": "^2.1.1",
+                "@smithy/core": "^1.3.1",
+                "@smithy/fetch-http-handler": "^2.4.1",
+                "@smithy/hash-node": "^2.1.1",
+                "@smithy/invalid-dependency": "^2.1.1",
+                "@smithy/middleware-content-length": "^2.1.1",
+                "@smithy/middleware-endpoint": "^2.4.1",
+                "@smithy/middleware-retry": "^2.1.1",
+                "@smithy/middleware-serde": "^2.1.1",
+                "@smithy/middleware-stack": "^2.1.1",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/node-http-handler": "^2.3.1",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/smithy-client": "^2.3.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/url-parser": "^2.1.1",
+                "@smithy/util-base64": "^2.1.1",
+                "@smithy/util-body-length-browser": "^2.1.1",
+                "@smithy/util-body-length-node": "^2.2.1",
+                "@smithy/util-defaults-mode-browser": "^2.1.1",
+                "@smithy/util-defaults-mode-node": "^2.1.1",
+                "@smithy/util-endpoints": "^1.1.1",
+                "@smithy/util-middleware": "^2.1.1",
+                "@smithy/util-retry": "^2.1.1",
+                "@smithy/util-utf8": "^2.1.1",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/credential-provider-node": {
+              "version": "3.501.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.501.0.tgz",
+              "integrity": "sha512-NM62D8gYrQ1nyLYwW4k48B2/lMHDzHDcQccS1wJakr6bg5sdtG06CumwlVcY+LAa0o1xRnhHmh/yiwj/nN4avw==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/credential-provider-env": "3.496.0",
+                "@aws-sdk/credential-provider-ini": "3.501.0",
+                "@aws-sdk/credential-provider-process": "3.496.0",
+                "@aws-sdk/credential-provider-sso": "3.501.0",
+                "@aws-sdk/credential-provider-web-identity": "3.496.0",
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/credential-provider-imds": "^2.2.1",
+                "@smithy/property-provider": "^2.1.1",
+                "@smithy/shared-ini-file-loader": "^2.3.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-host-header": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+              "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-logger": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+              "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-recursion-detection": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+              "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-signing": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+              "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/property-provider": "^2.1.1",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/signature-v4": "^2.1.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-middleware": "^2.1.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-user-agent": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+              "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@aws-sdk/util-endpoints": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/region-config-resolver": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+              "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-config-provider": "^2.2.1",
+                "@smithy/util-middleware": "^2.1.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/types": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+              "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+              "dev": true,
+              "requires": {
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-endpoints": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+              "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-endpoints": "^1.1.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-user-agent-browser": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+              "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-user-agent-node": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+              "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            }
+          }
+        },
         "@aws-sdk/client-ec2": {
           "version": "3.428.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.428.0.tgz",
@@ -22829,6 +24337,161 @@
             "uuid": "^8.3.2"
           }
         },
+        "@aws-sdk/client-sso": {
+          "version": "3.496.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+          "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/core": "3.496.0",
+            "@aws-sdk/middleware-host-header": "3.496.0",
+            "@aws-sdk/middleware-logger": "3.496.0",
+            "@aws-sdk/middleware-recursion-detection": "3.496.0",
+            "@aws-sdk/middleware-user-agent": "3.496.0",
+            "@aws-sdk/region-config-resolver": "3.496.0",
+            "@aws-sdk/types": "3.496.0",
+            "@aws-sdk/util-endpoints": "3.496.0",
+            "@aws-sdk/util-user-agent-browser": "3.496.0",
+            "@aws-sdk/util-user-agent-node": "3.496.0",
+            "@smithy/config-resolver": "^2.1.1",
+            "@smithy/core": "^1.3.1",
+            "@smithy/fetch-http-handler": "^2.4.1",
+            "@smithy/hash-node": "^2.1.1",
+            "@smithy/invalid-dependency": "^2.1.1",
+            "@smithy/middleware-content-length": "^2.1.1",
+            "@smithy/middleware-endpoint": "^2.4.1",
+            "@smithy/middleware-retry": "^2.1.1",
+            "@smithy/middleware-serde": "^2.1.1",
+            "@smithy/middleware-stack": "^2.1.1",
+            "@smithy/node-config-provider": "^2.2.1",
+            "@smithy/node-http-handler": "^2.3.1",
+            "@smithy/protocol-http": "^3.1.1",
+            "@smithy/smithy-client": "^2.3.1",
+            "@smithy/types": "^2.9.1",
+            "@smithy/url-parser": "^2.1.1",
+            "@smithy/util-base64": "^2.1.1",
+            "@smithy/util-body-length-browser": "^2.1.1",
+            "@smithy/util-body-length-node": "^2.2.1",
+            "@smithy/util-defaults-mode-browser": "^2.1.1",
+            "@smithy/util-defaults-mode-node": "^2.1.1",
+            "@smithy/util-endpoints": "^1.1.1",
+            "@smithy/util-retry": "^2.1.1",
+            "@smithy/util-utf8": "^2.1.1",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@aws-sdk/middleware-host-header": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+              "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-logger": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+              "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-recursion-detection": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+              "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-user-agent": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+              "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@aws-sdk/util-endpoints": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/region-config-resolver": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+              "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-config-provider": "^2.2.1",
+                "@smithy/util-middleware": "^2.1.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/types": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+              "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+              "dev": true,
+              "requires": {
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-endpoints": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+              "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-endpoints": "^1.1.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-user-agent-browser": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+              "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-user-agent-node": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+              "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            }
+          }
+        },
         "@aws-sdk/client-sts": {
           "version": "3.428.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.428.0.tgz",
@@ -22872,6 +24535,560 @@
             "@smithy/util-utf8": "^2.0.0",
             "fast-xml-parser": "4.2.5",
             "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/core": {
+          "version": "3.496.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
+          "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
+          "dev": true,
+          "requires": {
+            "@smithy/core": "^1.3.1",
+            "@smithy/protocol-http": "^3.1.1",
+            "@smithy/signature-v4": "^2.1.1",
+            "@smithy/smithy-client": "^2.3.1",
+            "@smithy/types": "^2.9.1",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@aws-sdk/credential-provider-cognito-identity": {
+          "version": "3.501.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.501.0.tgz",
+          "integrity": "sha512-U9fjzliKzMiPx/EWLNLCEoF5wWhVtlluTEc4/WhNtSryV2PyihqIAK8nK4+MFaXB4xOrlRnpYMd7oqm03wMGyw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-cognito-identity": "3.501.0",
+            "@aws-sdk/types": "3.496.0",
+            "@smithy/property-provider": "^2.1.1",
+            "@smithy/types": "^2.9.1",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+              "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+              "dev": true,
+              "requires": {
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.496.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+          "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.496.0",
+            "@smithy/property-provider": "^2.1.1",
+            "@smithy/types": "^2.9.1",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+              "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+              "dev": true,
+              "requires": {
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-http": {
+          "version": "3.496.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.496.0.tgz",
+          "integrity": "sha512-iphFlFX0qDFsE24XmFlcKmsR4uyNaqQrK+Y18mwSZMs1yWtL4Sck0rcTXU/cU2W3/xisjh7xFXK5L5aowjMZOg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.496.0",
+            "@smithy/fetch-http-handler": "^2.4.1",
+            "@smithy/node-http-handler": "^2.3.1",
+            "@smithy/property-provider": "^2.1.1",
+            "@smithy/protocol-http": "^3.1.1",
+            "@smithy/smithy-client": "^2.3.1",
+            "@smithy/types": "^2.9.1",
+            "@smithy/util-stream": "^2.1.1",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+              "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+              "dev": true,
+              "requires": {
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.501.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.501.0.tgz",
+          "integrity": "sha512-6UXnwLtYIr298ljveumCVXsH+x7csGscK5ylY+veRFy514NqyloRdJt8JY26hhh5SF9MYnkW+JyWSJ2Ls3tOjQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.496.0",
+            "@aws-sdk/credential-provider-process": "3.496.0",
+            "@aws-sdk/credential-provider-sso": "3.501.0",
+            "@aws-sdk/credential-provider-web-identity": "3.496.0",
+            "@aws-sdk/types": "3.496.0",
+            "@smithy/credential-provider-imds": "^2.2.1",
+            "@smithy/property-provider": "^2.1.1",
+            "@smithy/shared-ini-file-loader": "^2.3.1",
+            "@smithy/types": "^2.9.1",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+              "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+              "dev": true,
+              "requires": {
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.496.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+          "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.496.0",
+            "@smithy/property-provider": "^2.1.1",
+            "@smithy/shared-ini-file-loader": "^2.3.1",
+            "@smithy/types": "^2.9.1",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+              "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+              "dev": true,
+              "requires": {
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.501.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.501.0.tgz",
+          "integrity": "sha512-y90dlvvZ55PwecODFdMx0NiNlJJfm7X6S61PKdLNCMRcu1YK+eWn0CmPHGHobBUQ4SEYhnFLcHSsf+VMim6BtQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.496.0",
+            "@aws-sdk/token-providers": "3.501.0",
+            "@aws-sdk/types": "3.496.0",
+            "@smithy/property-provider": "^2.1.1",
+            "@smithy/shared-ini-file-loader": "^2.3.1",
+            "@smithy/types": "^2.9.1",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+              "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+              "dev": true,
+              "requires": {
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            }
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.496.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+          "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.496.0",
+            "@smithy/property-provider": "^2.1.1",
+            "@smithy/types": "^2.9.1",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+              "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+              "dev": true,
+              "requires": {
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            }
+          }
+        },
+        "@aws-sdk/credential-providers": {
+          "version": "3.501.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.501.0.tgz",
+          "integrity": "sha512-nyfGzzYKcAny2kUyQjVDhSzfFTwkfZjGyJZ79WaLkNcCsVSsHBbptPRmRV2b4N0EoHTCfGqkbB02as4av/OQrw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-cognito-identity": "3.501.0",
+            "@aws-sdk/client-sso": "3.496.0",
+            "@aws-sdk/client-sts": "3.501.0",
+            "@aws-sdk/credential-provider-cognito-identity": "3.501.0",
+            "@aws-sdk/credential-provider-env": "3.496.0",
+            "@aws-sdk/credential-provider-http": "3.496.0",
+            "@aws-sdk/credential-provider-ini": "3.501.0",
+            "@aws-sdk/credential-provider-node": "3.501.0",
+            "@aws-sdk/credential-provider-process": "3.496.0",
+            "@aws-sdk/credential-provider-sso": "3.501.0",
+            "@aws-sdk/credential-provider-web-identity": "3.496.0",
+            "@aws-sdk/types": "3.496.0",
+            "@smithy/credential-provider-imds": "^2.2.1",
+            "@smithy/property-provider": "^2.1.1",
+            "@smithy/types": "^2.9.1",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@aws-sdk/client-sts": {
+              "version": "3.501.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.501.0.tgz",
+              "integrity": "sha512-Uwc/xuxsA46dZS5s+4U703LBNDrGpWF7RB4XYEEMD21BLfGuqntxLLQux8xxKt3Pcur0CsXNja5jXt3uLnE5MA==",
+              "dev": true,
+              "requires": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/core": "3.496.0",
+                "@aws-sdk/credential-provider-node": "3.501.0",
+                "@aws-sdk/middleware-host-header": "3.496.0",
+                "@aws-sdk/middleware-logger": "3.496.0",
+                "@aws-sdk/middleware-recursion-detection": "3.496.0",
+                "@aws-sdk/middleware-user-agent": "3.496.0",
+                "@aws-sdk/region-config-resolver": "3.496.0",
+                "@aws-sdk/types": "3.496.0",
+                "@aws-sdk/util-endpoints": "3.496.0",
+                "@aws-sdk/util-user-agent-browser": "3.496.0",
+                "@aws-sdk/util-user-agent-node": "3.496.0",
+                "@smithy/config-resolver": "^2.1.1",
+                "@smithy/core": "^1.3.1",
+                "@smithy/fetch-http-handler": "^2.4.1",
+                "@smithy/hash-node": "^2.1.1",
+                "@smithy/invalid-dependency": "^2.1.1",
+                "@smithy/middleware-content-length": "^2.1.1",
+                "@smithy/middleware-endpoint": "^2.4.1",
+                "@smithy/middleware-retry": "^2.1.1",
+                "@smithy/middleware-serde": "^2.1.1",
+                "@smithy/middleware-stack": "^2.1.1",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/node-http-handler": "^2.3.1",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/smithy-client": "^2.3.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/url-parser": "^2.1.1",
+                "@smithy/util-base64": "^2.1.1",
+                "@smithy/util-body-length-browser": "^2.1.1",
+                "@smithy/util-body-length-node": "^2.2.1",
+                "@smithy/util-defaults-mode-browser": "^2.1.1",
+                "@smithy/util-defaults-mode-node": "^2.1.1",
+                "@smithy/util-endpoints": "^1.1.1",
+                "@smithy/util-middleware": "^2.1.1",
+                "@smithy/util-retry": "^2.1.1",
+                "@smithy/util-utf8": "^2.1.1",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/credential-provider-node": {
+              "version": "3.501.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.501.0.tgz",
+              "integrity": "sha512-NM62D8gYrQ1nyLYwW4k48B2/lMHDzHDcQccS1wJakr6bg5sdtG06CumwlVcY+LAa0o1xRnhHmh/yiwj/nN4avw==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/credential-provider-env": "3.496.0",
+                "@aws-sdk/credential-provider-ini": "3.501.0",
+                "@aws-sdk/credential-provider-process": "3.496.0",
+                "@aws-sdk/credential-provider-sso": "3.501.0",
+                "@aws-sdk/credential-provider-web-identity": "3.496.0",
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/credential-provider-imds": "^2.2.1",
+                "@smithy/property-provider": "^2.1.1",
+                "@smithy/shared-ini-file-loader": "^2.3.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-host-header": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+              "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-logger": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+              "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-recursion-detection": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+              "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-user-agent": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+              "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@aws-sdk/util-endpoints": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/region-config-resolver": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+              "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-config-provider": "^2.2.1",
+                "@smithy/util-middleware": "^2.1.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/types": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+              "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+              "dev": true,
+              "requires": {
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-endpoints": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+              "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-endpoints": "^1.1.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-user-agent-browser": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+              "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-user-agent-node": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+              "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            }
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.501.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.501.0.tgz",
+          "integrity": "sha512-MvLPhNxlStmQqVm2crGLUqYWvK/AbMmI9j4FbEfJ15oG/I+730zjSJQEy2MvdiqbJRDPZ/tRCL89bUedOrmi0g==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "3.0.0",
+            "@aws-crypto/sha256-js": "3.0.0",
+            "@aws-sdk/middleware-host-header": "3.496.0",
+            "@aws-sdk/middleware-logger": "3.496.0",
+            "@aws-sdk/middleware-recursion-detection": "3.496.0",
+            "@aws-sdk/middleware-user-agent": "3.496.0",
+            "@aws-sdk/region-config-resolver": "3.496.0",
+            "@aws-sdk/types": "3.496.0",
+            "@aws-sdk/util-endpoints": "3.496.0",
+            "@aws-sdk/util-user-agent-browser": "3.496.0",
+            "@aws-sdk/util-user-agent-node": "3.496.0",
+            "@smithy/config-resolver": "^2.1.1",
+            "@smithy/fetch-http-handler": "^2.4.1",
+            "@smithy/hash-node": "^2.1.1",
+            "@smithy/invalid-dependency": "^2.1.1",
+            "@smithy/middleware-content-length": "^2.1.1",
+            "@smithy/middleware-endpoint": "^2.4.1",
+            "@smithy/middleware-retry": "^2.1.1",
+            "@smithy/middleware-serde": "^2.1.1",
+            "@smithy/middleware-stack": "^2.1.1",
+            "@smithy/node-config-provider": "^2.2.1",
+            "@smithy/node-http-handler": "^2.3.1",
+            "@smithy/property-provider": "^2.1.1",
+            "@smithy/protocol-http": "^3.1.1",
+            "@smithy/shared-ini-file-loader": "^2.3.1",
+            "@smithy/smithy-client": "^2.3.1",
+            "@smithy/types": "^2.9.1",
+            "@smithy/url-parser": "^2.1.1",
+            "@smithy/util-base64": "^2.1.1",
+            "@smithy/util-body-length-browser": "^2.1.1",
+            "@smithy/util-body-length-node": "^2.2.1",
+            "@smithy/util-defaults-mode-browser": "^2.1.1",
+            "@smithy/util-defaults-mode-node": "^2.1.1",
+            "@smithy/util-endpoints": "^1.1.1",
+            "@smithy/util-retry": "^2.1.1",
+            "@smithy/util-utf8": "^2.1.1",
+            "tslib": "^2.5.0"
+          },
+          "dependencies": {
+            "@aws-sdk/middleware-host-header": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+              "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-logger": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+              "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-recursion-detection": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+              "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/middleware-user-agent": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+              "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@aws-sdk/util-endpoints": "3.496.0",
+                "@smithy/protocol-http": "^3.1.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/region-config-resolver": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+              "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-config-provider": "^2.2.1",
+                "@smithy/util-middleware": "^2.1.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/types": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
+              "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
+              "dev": true,
+              "requires": {
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-endpoints": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+              "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "@smithy/util-endpoints": "^1.1.1",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-user-agent-browser": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+              "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/types": "^2.9.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+              }
+            },
+            "@aws-sdk/util-user-agent-node": {
+              "version": "3.496.0",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+              "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
+              "dev": true,
+              "requires": {
+                "@aws-sdk/types": "3.496.0",
+                "@smithy/node-config-provider": "^2.2.1",
+                "@smithy/types": "^2.9.1",
+                "tslib": "^2.5.0"
+              }
+            }
           }
         }
       }
@@ -23714,9 +25931,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+          "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
           "dev": true
         }
       }
@@ -23731,9 +25948,9 @@
       }
     },
     "@npmcli/git": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.3.tgz",
-      "integrity": "sha512-UZp9NwK+AynTrKvHn5k3KviW/hA5eENmFsu3iAPe7sWRt0lFUdsY/wXIYjpDFe7cdSNwOIzbObfwgt6eL5/2zw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.4.tgz",
+      "integrity": "sha512-nr6/WezNzuYUppzXRaYu/W4aT5rLxdXqEFupbh6e/ovlYFQ8hpu1UUPV3Ir/YTl+74iXl2ZOMlGzudh9ZPUchQ==",
       "dev": true,
       "requires": {
         "@npmcli/promise-spawn": "^7.0.0",
@@ -23753,9 +25970,9 @@
           "dev": true
         },
         "lru-cache": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+          "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
           "dev": true
         },
         "which": {
@@ -23785,10 +26002,73 @@
       "integrity": "sha512-gp8pRXC2oOxu0DUE1/M3bYtb1b3/DbJ5aM113+XJBgfXdussRAsX0YOrOhdd8WvnAR6auDBvJomGAkLKA5ydxA==",
       "dev": true
     },
+    "@npmcli/package-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.0.tgz",
+      "integrity": "sha512-OI2zdYBLhQ7kpNPaJxiflofYIpkNLi+lnGdzqUOfRmCF3r2l1nadcjtCYMJKv/Utm/ZtlffaUuTiAktPHbc17g==",
+      "dev": true,
+      "requires": {
+        "@npmcli/git": "^5.0.0",
+        "glob": "^10.2.2",
+        "hosted-git-info": "^7.0.0",
+        "json-parse-even-better-errors": "^3.0.0",
+        "normalize-package-data": "^6.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.5.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "10.3.10",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+          "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^2.3.5",
+            "minimatch": "^9.0.1",
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+            "path-scurry": "^1.10.1"
+          }
+        },
+        "hosted-git-info": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+          "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^10.0.1"
+          }
+        },
+        "json-parse-even-better-errors": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
+          "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+          "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
+          "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^7.0.0",
+            "is-core-module": "^2.8.1",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4"
+          }
+        }
+      }
+    },
     "@npmcli/promise-spawn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.0.tgz",
-      "integrity": "sha512-wBqcGsMELZna0jDblGd7UXgOby45TQaMWmbFwWX+SEotk4HV6zG2t6rT9siyLhPk4P6YYqgfL1UO8nMWDBVJXQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.1.tgz",
+      "integrity": "sha512-P4KkF9jX3y+7yFUxgcUdDtLy+t4OlDGuEBLNs57AZsfSfg+uV6MLndqGpnl4831ggaEdXwR50XFoZP4VFtHolg==",
       "dev": true,
       "requires": {
         "which": "^4.0.0"
@@ -23812,15 +26092,15 @@
       }
     },
     "@npmcli/run-script": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-7.0.2.tgz",
-      "integrity": "sha512-Omu0rpA8WXvcGeY6DDzyRoY1i5DkCBkzyJ+m2u7PD6quzb0TvSqdIPOkTn8ZBOj7LbbcbMfZ3c5skwSu6m8y2w==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-7.0.4.tgz",
+      "integrity": "sha512-9ApYM/3+rBt9V80aYg6tZfzj3UWdiYyCt7gJUD1VJKvWF5nwKDSICXbYIQbspFTq6TOpbsEtIC0LArB8d9PFmg==",
       "dev": true,
       "requires": {
         "@npmcli/node-gyp": "^3.0.0",
+        "@npmcli/package-json": "^5.0.0",
         "@npmcli/promise-spawn": "^7.0.0",
         "node-gyp": "^10.0.0",
-        "read-package-json-fast": "^3.0.0",
         "which": "^4.0.0"
       },
       "dependencies": {
@@ -23860,13 +26140,19 @@
       }
     },
     "@sigstore/bundle": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.1.0.tgz",
-      "integrity": "sha512-89uOo6yh/oxaU8AeOUnVrTdVMcGk9Q1hJa7Hkvalc6G3Z3CupWk4Xe9djSgJm9fMkH69s0P0cVHUoKSOemLdng==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.1.1.tgz",
+      "integrity": "sha512-v3/iS+1nufZdKQ5iAlQKcCsoh0jffQyABvYIxKsZQFWc4ubuGjwZklFHpDgV6O6T7vvV78SW5NHI91HFKEcxKg==",
       "dev": true,
       "requires": {
         "@sigstore/protobuf-specs": "^0.2.1"
       }
+    },
+    "@sigstore/core": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-THobAPPZR9pDH2CAvDLpkrYedt7BlZnsyxDe+Isq4ZmGfPy5juOFZq487vCU2EgKD7aHSiTfE/i7sN7aEdzQnA==",
+      "dev": true
     },
     "@sigstore/protobuf-specs": {
       "version": "0.2.1",
@@ -23875,24 +26161,36 @@
       "dev": true
     },
     "@sigstore/sign": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.2.0.tgz",
-      "integrity": "sha512-AAbmnEHDQv6CSfrWA5wXslGtzLPtAtHZleKOgxdQYvx/s76Fk6T6ZVt7w2IGV9j1UrFeBocTTQxaXG2oRrDhYA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.2.1.tgz",
+      "integrity": "sha512-U5sKQEj+faE1MsnLou1f4DQQHeFZay+V9s9768lw48J4pKykPj34rWyI1lsMOGJ3Mae47Ye6q3HAJvgXO21rkQ==",
       "dev": true,
       "requires": {
-        "@sigstore/bundle": "^2.1.0",
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
         "@sigstore/protobuf-specs": "^0.2.1",
         "make-fetch-happen": "^13.0.0"
       }
     },
     "@sigstore/tuf": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-2.2.0.tgz",
-      "integrity": "sha512-KKATZ5orWfqd9ZG6MN8PtCIx4eevWSuGRKQvofnWXRpyMyUEpmrzg5M5BrCpjM+NfZ0RbNGOh5tCz/P2uoRqOA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-2.3.0.tgz",
+      "integrity": "sha512-S98jo9cpJwO1mtQ+2zY7bOdcYyfVYCUaofCG6wWRzk3pxKHVAkSfshkfecto2+LKsx7Ovtqbgb2LS8zTRhxJ9Q==",
       "dev": true,
       "requires": {
         "@sigstore/protobuf-specs": "^0.2.1",
-        "tuf-js": "^2.1.0"
+        "tuf-js": "^2.2.0"
+      }
+    },
+    "@sigstore/verify": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-0.1.0.tgz",
+      "integrity": "sha512-2UzMNYAa/uaz11NhvgRnIQf4gpLTJ59bhb8ESXaoSS5sxedfS+eLak8bsdMc+qpNQfITUTFoSKFx5h8umlRRiA==",
+      "dev": true,
+      "requires": {
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
+        "@sigstore/protobuf-specs": "^0.2.1"
       }
     },
     "@sinonjs/commons": {
@@ -23942,11 +26240,11 @@
       "dev": true
     },
     "@smithy/abort-controller": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
-      "integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+      "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
@@ -23968,37 +26266,53 @@
       }
     },
     "@smithy/config-resolver": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.16.tgz",
-      "integrity": "sha512-1k+FWHQDt2pfpXhJsOmNMmlAZ3NUQ98X5tYsjQhVGq+0X6cOBMhfh6Igd0IX3Ut6lEO6DQAdPMI/blNr3JZfMQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+      "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
       "requires": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/core": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.1.tgz",
+      "integrity": "sha512-tf+NIu9FkOh312b6M9G4D68is4Xr7qptzaZGZUREELF8ysE1yLKphqt7nsomjKZVwW7WE5pDDex9idowNGRQ/Q==",
+      "dev": true,
+      "requires": {
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.18.tgz",
-      "integrity": "sha512-QnPBi6D2zj6AHJdUTo5zXmk8vwHJ2bNevhcVned1y+TZz/OI5cizz5DsYNkqFUIDn8tBuEyKNgbmKVNhBbuY3g==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+      "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
       "requires": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/eventstream-codec": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.12.tgz",
-      "integrity": "sha512-ZZQLzHBJkbiAAdj2C5K+lBlYp/XJ+eH2uy+jgJgYIFW/o5AM59Hlj7zyI44/ZTDIQWmBxb3EFv/c5t44V8/g8A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -24042,14 +26356,14 @@
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.4.tgz",
-      "integrity": "sha512-gIPRFEGi+c6V52eauGKrjDzPWF2Cu7Z1r5F8A3j2wcwz25sPG/t8kjsbEhli/tS/2zJp/ybCZXe4j4ro3yv/HA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+      "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
       "requires": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -24065,13 +26379,13 @@
       }
     },
     "@smithy/hash-node": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.12.tgz",
-      "integrity": "sha512-fDZnTr5j9t5qcbeJ037aMZXxMka13Znqwrgy3PAqYj6Dm3XHXHftTH3q+NWgayUxl1992GFtQt1RuEzRMy3NnQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+      "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
       "requires": {
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -24086,18 +26400,18 @@
       }
     },
     "@smithy/invalid-dependency": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.12.tgz",
-      "integrity": "sha512-p5Y+iMHV3SoEpy3VSR7mifbreHQwVSvHSAz/m4GdoXfOzKzaYC8hYv10Ks7Deblkf7lhas8U+lAp9ThbBM+ZXA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+      "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
       "requires": {
         "tslib": "^2.5.0"
       }
@@ -24113,290 +26427,304 @@
       }
     },
     "@smithy/middleware-content-length": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.14.tgz",
-      "integrity": "sha512-poUNgKTw9XwPXfX9nEHpVgrMNVpaSMZbshqvPxFVoalF4wp6kRzYKOfdesSVectlQ51VtigoLfbXcdyPwvxgTg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+      "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
       "requires": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.3.tgz",
-      "integrity": "sha512-ZrQ0/YX6hNVTxqMEHtEaDbDv6pNeEji/a5Vk3HuFC5R3ZY8lfoATyxmOGxBVYnF3NUvZLNC7umEv1WzWGWvCGQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+      "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
       "requires": {
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/shared-ini-file-loader": "^2.2.2",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-middleware": "^2.0.5",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-retry": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.18.tgz",
-      "integrity": "sha512-VyrHQRldGSb3v9oFOB5yPxmLT7U2sQic2ytylOnYlnsmVOLlFIaI6sW22c+w2675yq+XZ6HOuzV7x2OBYCWRNA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+      "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
       "requires": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "@smithy/util-retry": "^2.0.5",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       }
     },
     "@smithy/middleware-serde": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
-      "integrity": "sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+      "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-stack": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
-      "integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+      "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/node-config-provider": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.3.tgz",
-      "integrity": "sha512-J6lXvRHGVnSX3n1PYi+e1L5HN73DkkJpUviV3Ebf+8wSaIjAf+eVNbzyvh/S5EQz7nf4KVfwbD5vdoZMAthAEQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+      "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
       "requires": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/shared-ini-file-loader": "^2.2.2",
-        "@smithy/types": "^2.4.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/node-http-handler": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
-      "integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+      "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
       "requires": {
-        "@smithy/abort-controller": "^2.0.12",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/property-provider": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
-      "integrity": "sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+      "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+      "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/querystring-builder": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
-      "integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+      "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
       "requires": {
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-uri-escape": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/querystring-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
-      "integrity": "sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+      "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/service-error-classification": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.5.tgz",
-      "integrity": "sha512-M0SeJnEgD2ywJyV99Fb1yKFzmxDe9JfpJiYTVSRMyRLc467BPU0qsuuDPzMCdB1mU8M8u1rVOdkqdoyFN8UFTw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
       "requires": {
-        "@smithy/types": "^2.4.0"
+        "@smithy/types": "^2.9.1"
       }
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.2.tgz",
-      "integrity": "sha512-noyQUPn7b1M8uB0GEXc/Zyxq+5K2b7aaqWnLp+hgJ7+xu/FCvtyWy5eWLDjQEsHnAet2IZhS5QF8872OR69uNg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/signature-v4": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.12.tgz",
-      "integrity": "sha512-6Kc2lCZEVmb1nNYngyNbWpq0d82OZwITH11SW/Q0U6PX5fH7B2cIcFe7o6eGEFPkTZTP8itTzmYiGcECL0D0Lw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
       "requires": {
-        "@smithy/eventstream-codec": "^2.0.12",
-        "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/eventstream-codec": "^2.1.1",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/smithy-client": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.12.tgz",
-      "integrity": "sha512-XXqhridfkKnpj+lt8vM6HRlZbqUAqBjVC74JIi13F/AYQd/zTj9SOyGfxnbp4mjY9q28LityxIuV8CTinr9r5w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+      "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
       "requires": {
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-stream": "^2.0.17",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/url-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.12.tgz",
-      "integrity": "sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+      "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
       "requires": {
-        "@smithy/querystring-parser": "^2.0.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/querystring-parser": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-base64": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
-      "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+      "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
       "requires": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-body-length-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+      "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-body-length-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+      "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
       "requires": {
-        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/is-array-buffer": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-config-provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+      "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.16.tgz",
-      "integrity": "sha512-Uv5Cu8nVkuvLn0puX+R9zWbSNpLIR3AxUlPoLJ7hC5lvir8B2WVqVEkJLwtixKAncVLasnTVjPDCidtAUTGEQw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+      "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
       "requires": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.21.tgz",
-      "integrity": "sha512-cUEsttVZ79B7Al2rWK2FW03HBpD9LyuqFtm+1qFty5u9sHSdesr215gS2Ln53fTopNiPgeXpdoM3IgjvIO0rJw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.1.1.tgz",
+      "integrity": "sha512-tYVrc+w+jSBfBd267KDnvSGOh4NMz+wVH7v4CClDbkdPfnjvImBZsOURncT5jsFwR9KCuDyPoSZq4Pa6+eCUrA==",
       "requires": {
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/credential-provider-imds": "^2.0.18",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/util-endpoints": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+      "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
+      "dev": true,
+      "requires": {
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-middleware": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
       "requires": {
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-retry": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.5.tgz",
-      "integrity": "sha512-x3t1+MQAJ6QONk3GTbJNcugCFDVJ+Bkro5YqQQK1EyVesajNDqxFtCx9WdOFNGm/Cbm7tUdwVEmfKQOJoU2Vtw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
       "requires": {
-        "@smithy/service-error-classification": "^2.0.5",
-        "@smithy/types": "^2.4.0",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-stream": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.17.tgz",
-      "integrity": "sha512-fP/ZQ27rRvHsqItds8yB7jerwMpZFTL3QqbQbidUiG0+mttMoKdP0ZqnvM8UK5q0/dfc3/pN7g4XKPXOU7oRWw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+      "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
       "requires": {
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -24496,19 +26824,19 @@
       }
     },
     "@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-utf8": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
       "requires": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -24523,61 +26851,61 @@
       }
     },
     "@tapjs/after": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/after/-/after-1.1.16.tgz",
-      "integrity": "sha512-/KwElRYMMN4pKDP0VT1a5d9RLsnV/HrnpvBbDJiavs816wQOEOwMt1q4rXVU2XO6cSpXn0cm77xBLDkkBlJQWA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/after/-/after-1.1.18.tgz",
+      "integrity": "sha512-r0vMFMfxmO6UR+pB9zGvamaeUI+yhLokYAagsKoM3JdoZgyq0iw1fHn5hPPY8AC1tAzEYG3KtVDpJfpoOr67Iw==",
       "dev": true,
       "requires": {
         "is-actual-promise": "^1.0.0"
       }
     },
     "@tapjs/after-each": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/after-each/-/after-each-1.1.16.tgz",
-      "integrity": "sha512-TlhGKfX+3GHwqGhMxNWZ50xb8vfwp2+kx0COTbuGLrwcCgwmpFPU/r/7td03BOtdCV2J1yKFxGiRDvZyowZLyg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/after-each/-/after-each-1.1.18.tgz",
+      "integrity": "sha512-AuXeD8uUYQ/CUdfhx2jvBhJf3M+T/Kroz5T6ItocZ3jf8H/4x2OKMVbb5YcB7J4ANGtmzXp+8SBseoN1av6y0Q==",
       "dev": true,
       "requires": {
         "function-loop": "^4.0.0"
       }
     },
     "@tapjs/asserts": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/asserts/-/asserts-1.1.16.tgz",
-      "integrity": "sha512-gf37N6VMv7iuaomB8Yr+3VyuPS77kXy6Uw2n2AHsiU47Q0eNodjrN0d2G+glfrXfD3zLbsLuQHx4x6IsAsgq7Q==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/asserts/-/asserts-1.1.18.tgz",
+      "integrity": "sha512-MwGs/QklLRAsMnB4fO6QFaZ0myR//E21Rek/gGCpTxz7eUwCh24/y7MlBV0W6zDFdnQ1GFbHc/fIBVtcPAWjyw==",
       "dev": true,
       "requires": {
         "@tapjs/stack": "1.2.7",
         "is-actual-promise": "^1.0.0",
-        "tcompare": "6.4.4",
+        "tcompare": "6.4.5",
         "trivial-deferred": "^2.0.0"
       }
     },
     "@tapjs/before": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/before/-/before-1.1.16.tgz",
-      "integrity": "sha512-3hO7eQbL1Ac8OgPq9+nBuQS4cz/eVGcaPDs0cTcTy3NYbhCrp4MGTpRtKxF4Cds1Y/rHAipB81MhZrmG7xBjlg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/before/-/before-1.1.18.tgz",
+      "integrity": "sha512-2rkXrAWlkl0+bZ8wSNfEW/7TANs/Dg5SrY2MmdEb0x7Q/zbMoGjrPVKDRF20Me0p+tJBLWSY+FXQ0OhXK0pUjg==",
       "dev": true,
       "requires": {
         "is-actual-promise": "^1.0.0"
       }
     },
     "@tapjs/before-each": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/before-each/-/before-each-1.1.16.tgz",
-      "integrity": "sha512-yJAt0yGOQFnozmm2fQSfAELp/hMzudYOr4udANZ/1RIVJYXHThj0qrUZP9nEkXMWK4wRQytOInt1jEwXR/cFfQ==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/before-each/-/before-each-1.1.18.tgz",
+      "integrity": "sha512-qxBQaOY+IkThP9iauL1tHCxirG9XuKGJvGHY4IGKuk0RswWkXmawSe5hcJ8m569dRXy9yJHEV7N0QueuyWxpBA==",
       "dev": true,
       "requires": {
         "function-loop": "^4.0.0"
       }
     },
     "@tapjs/config": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/@tapjs/config/-/config-2.4.12.tgz",
-      "integrity": "sha512-7l7dqKuYXm9zNj7c1QFoWqYxOtshP69KyU3q4vSh8xJmTzz19miZbfx881f8SIb3/PtDqTilv1CFxEaKuZgmEw==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@tapjs/config/-/config-2.4.15.tgz",
+      "integrity": "sha512-uU/gfQJh8aSokEBgwAAHD5ctHYbIiZYFaL6IrROcDp7Wr7/fd/dn9K4efpREwKpqKqOgL3XZPOwx7prKxrLHhA==",
       "dev": true,
       "requires": {
-        "@tapjs/core": "1.4.5",
-        "@tapjs/test": "1.3.16",
+        "@tapjs/core": "1.5.0",
+        "@tapjs/test": "1.4.0",
         "chalk": "^5.2.0",
         "jackspeak": "^2.3.6",
         "polite-json": "^4.0.1",
@@ -24594,14 +26922,14 @@
       }
     },
     "@tapjs/core": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@tapjs/core/-/core-1.4.5.tgz",
-      "integrity": "sha512-vvLrM75t1/Yq2MlH1x3jfJPdPs4ArR+tFTpzNgQ+PF50x0PTDup1sVj7ZhZbNY4zeQFsvnVtoReptr3FsMix7Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-g+NNI5TGXVJR5G4AZCU0hWu1pdA2qB2OYrY9Ej3mWeg97mvNZBVgNtvx8Vjdwp9BfgbJfyFK7PvoB4nhKgetSQ==",
       "dev": true,
       "requires": {
         "@tapjs/processinfo": "^3.1.6",
         "@tapjs/stack": "1.2.7",
-        "@tapjs/test": "1.3.16",
+        "@tapjs/test": "1.4.0",
         "async-hook-domain": "^4.0.1",
         "diff": "^5.1.0",
         "is-actual-promise": "^1.0.0",
@@ -24609,7 +26937,7 @@
         "signal-exit": "4.1",
         "tap-parser": "15.3.1",
         "tap-yaml": "2.2.1",
-        "tcompare": "6.4.4",
+        "tcompare": "6.4.5",
         "trivial-deferred": "^2.0.0"
       },
       "dependencies": {
@@ -24631,16 +26959,16 @@
       }
     },
     "@tapjs/filter": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/filter/-/filter-1.2.16.tgz",
-      "integrity": "sha512-TiOjFMy+Sg5Lnm5pzUcjgpyw19bEg0WejLGpml0DPQi/OEVYlazu2lcDQFRgpRBhvYlOc7we9nul2y2a3Jh8PQ==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/filter/-/filter-1.2.18.tgz",
+      "integrity": "sha512-0yCqaHYLejI/KyxdB5EsrRVu3wxZVl7vPXTwBoyc+ycJWXPapHLhKl67Xk5x3FW/nNelA9TCq/tSHcYlogGN0g==",
       "dev": true,
       "requires": {}
     },
     "@tapjs/fixture": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/fixture/-/fixture-1.2.16.tgz",
-      "integrity": "sha512-9+QUkGW4CoSR4cKO3vLe9YYsBgD9wCRvta5jxquTWk9VJiVQZ3pKIqaSULB47kUZbtERorhvI7J5YCYWnVbF7A==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/fixture/-/fixture-1.2.18.tgz",
+      "integrity": "sha512-BQIRxydaqjZIG61QhoiQOc9HE3MxSjCn7SUsIfYCzoZoY+3aY6iCdTVg2la86b5ikTbwoWxWWbqICnFWebuHnQ==",
       "dev": true,
       "requires": {
         "mkdirp": "^3.0.0",
@@ -24678,31 +27006,31 @@
       }
     },
     "@tapjs/intercept": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/intercept/-/intercept-1.2.16.tgz",
-      "integrity": "sha512-Mgw3ib7bu2cFjbeujFw6y7CcEq1mNd/EQhrg1L9Q96bETtp9YNSlox4Z7MKmTEtnk9fzuCIVs7T9QbI8eq2k7w==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/intercept/-/intercept-1.2.18.tgz",
+      "integrity": "sha512-Trcmp64RKD2/nMz7/+NuwjJHfrn8eFofX3s3g0+QGvnTv+5B5ZQs+zWjS7q2d1Qt8LDV8CfS5w3BhYyONsocSw==",
       "dev": true,
       "requires": {
-        "@tapjs/after": "1.1.16",
+        "@tapjs/after": "1.1.18",
         "@tapjs/stack": "1.2.7"
       }
     },
     "@tapjs/mock": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@tapjs/mock/-/mock-1.2.14.tgz",
-      "integrity": "sha512-HnXUmkn3xk4gzoMb3s77EK2CJaBzAoi1hzyyE6abBJf8dnLCid4xUOs+H4KybWllKcwwIUr0yzKmXJl7eCWVbQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/mock/-/mock-1.3.0.tgz",
+      "integrity": "sha512-Uzyikl8SS8Mg7OOr2HuyiaVhYvHNRZnw6A1/qTiJnoZ1MHcLFuwFqIX9ZhfXMil5MIYC/ET096VMDm45q9Tdvw==",
       "dev": true,
       "requires": {
-        "@tapjs/after": "1.1.16",
+        "@tapjs/after": "1.1.18",
         "@tapjs/stack": "1.2.7",
         "resolve-import": "^1.4.5",
         "walk-up-path": "^3.0.1"
       }
     },
     "@tapjs/node-serialize": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@tapjs/node-serialize/-/node-serialize-1.2.5.tgz",
-      "integrity": "sha512-y7QS5Sev6QQ0O+sx5WjY11XoUBzuNdSNDwVRxrj1qwTuigRVj+1ePWutP80pn7bE/r2G+2L2IHuEsMDRLCgulw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/node-serialize/-/node-serialize-1.3.0.tgz",
+      "integrity": "sha512-52oQKQJMMKrI1cNu8kJ5WTv8YFnbhwfwUs3Jh1vXQb4tOhLW8IHWqXBi5AiNL3HlCMMHaKDFQjW6sbbJuMyJPA==",
       "dev": true,
       "requires": {
         "@tapjs/error-serdes": "1.2.1",
@@ -24731,12 +27059,12 @@
       }
     },
     "@tapjs/reporter": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@tapjs/reporter/-/reporter-1.3.13.tgz",
-      "integrity": "sha512-yiEPF1NfcD5RaosIFq3wqT05/3S3caHEY+eG6MwH+xmZSO0Fv7Q/t9qXoWfuQOyMiIARjhKQfGdqHYXbC50f+Q==",
+      "version": "1.3.16",
+      "resolved": "https://registry.npmjs.org/@tapjs/reporter/-/reporter-1.3.16.tgz",
+      "integrity": "sha512-YoZpBAFGdZyrhIaRCZDuWSeCc10A3YG/4mIdPsKpSbLXPBZ1hwCV8Y/LPCpH5kunZTXYocvQoRHU+oD4pLXC3g==",
       "dev": true,
       "requires": {
-        "@tapjs/config": "2.4.12",
+        "@tapjs/config": "2.4.15",
         "@tapjs/stack": "1.2.7",
         "chalk": "^5.2.0",
         "ink": "^4.4.1",
@@ -24748,7 +27076,7 @@
         "string-length": "^6.0.0",
         "tap-parser": "15.3.1",
         "tap-yaml": "2.2.1",
-        "tcompare": "6.4.4"
+        "tcompare": "6.4.5"
       },
       "dependencies": {
         "chalk": {
@@ -24766,19 +27094,19 @@
       }
     },
     "@tapjs/run": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@tapjs/run/-/run-1.4.14.tgz",
-      "integrity": "sha512-jkOMWlxAUTjPtJqLWHVAbH4hkaj/oAf6W20rA+gRhxZQ7VtAgEgVavV3lSaNM3gPmgZwiJZezX+hHO3nDkCfrg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/run/-/run-1.5.0.tgz",
+      "integrity": "sha512-WrmbHHrhvRvLlTTAGiogF09xiPoorsoG4diAIKifGUyGD/9qRA7pT2mzYIqXvhyxbtuEmaeobHjupSZrak+O4Q==",
       "dev": true,
       "requires": {
-        "@tapjs/after": "1.1.16",
-        "@tapjs/before": "1.1.16",
-        "@tapjs/config": "2.4.12",
+        "@tapjs/after": "1.1.18",
+        "@tapjs/before": "1.1.18",
+        "@tapjs/config": "2.4.15",
         "@tapjs/processinfo": "^3.1.6",
-        "@tapjs/reporter": "1.3.13",
-        "@tapjs/spawn": "1.1.16",
-        "@tapjs/stdin": "1.1.16",
-        "@tapjs/test": "1.3.16",
+        "@tapjs/reporter": "1.3.16",
+        "@tapjs/spawn": "1.1.18",
+        "@tapjs/stdin": "1.1.18",
+        "@tapjs/test": "1.4.0",
         "c8": "^8.0.1",
         "chalk": "^5.3.0",
         "chokidar": "^3.5.3",
@@ -24794,7 +27122,7 @@
         "signal-exit": "^4.1.0",
         "tap-parser": "15.3.1",
         "tap-yaml": "2.2.1",
-        "tcompare": "6.4.4",
+        "tcompare": "6.4.5",
         "trivial-deferred": "^2.0.0",
         "which": "^4.0.0"
       },
@@ -24857,20 +27185,20 @@
       }
     },
     "@tapjs/snapshot": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/snapshot/-/snapshot-1.2.16.tgz",
-      "integrity": "sha512-4Da9TXAQ3ni+JC8AfzDKRQG6cIjT/LxTTGmVDK4/Fe4NubdNKw/A76Gvl9xPUIlqW1vNZVGVN/0KruEDKJ4xkQ==",
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/snapshot/-/snapshot-1.2.18.tgz",
+      "integrity": "sha512-fHt4ZgutJ922/YdmXN2d6dkwFTR6KsyD02jcSYBXVDGdFC2YnsjKk/o9s3Yt9tYnYES6Et+6udPlAKcakzR5jQ==",
       "dev": true,
       "requires": {
         "is-actual-promise": "^1.0.0",
-        "tcompare": "6.4.4",
+        "tcompare": "6.4.5",
         "trivial-deferred": "^2.0.0"
       }
     },
     "@tapjs/spawn": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/spawn/-/spawn-1.1.16.tgz",
-      "integrity": "sha512-Y0/WNlFp8kkRwKNyOqYUrIwwY2sLkegakvhtcJsg9eg/P4CC9lnh+zaSEfgNGJb24S4qeWOOnJ/rQ68bK9HVYg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/spawn/-/spawn-1.1.18.tgz",
+      "integrity": "sha512-E5H0NTyTZ0FnkPUd5JU3c2KrnjjMDDAuctRd2b0v/M5LB+uAlwwEEJJ6rh+dBsFK/yatfgPli+nbHZVjUz+Usw==",
       "dev": true,
       "requires": {}
     },
@@ -24881,34 +27209,34 @@
       "dev": true
     },
     "@tapjs/stdin": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/stdin/-/stdin-1.1.16.tgz",
-      "integrity": "sha512-kP22n5kaoMcAp+elESvRCg/fodfeefsbtacTOGAfXnHLK+eh8XBSz1SwDmyaeQ4/C3F6SMQ8+8ZeybMcbeLEGQ==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/stdin/-/stdin-1.1.18.tgz",
+      "integrity": "sha512-UyhK8bRRhQkmBb7N/NFa/11DucHfIzCyyba7uax+dkuXSd6OccTZVxLpRMuaOUV59QCCFAJUJDQnmaWj35fI7Q==",
       "dev": true,
       "requires": {}
     },
     "@tapjs/test": {
-      "version": "1.3.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/test/-/test-1.3.16.tgz",
-      "integrity": "sha512-HalYruL4tpTgKVJQwkTh/vw5Mt7sEVXXoS7bTik8tyPr9wQ7UXTRPB2EErna89mhhRc0hYU4NYXlwzS1UHiQkQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/test/-/test-1.4.0.tgz",
+      "integrity": "sha512-t4U11uAUDUeBQTdlqtiDoiuiG3lKLhHa+PxrdIR3GlG+2wDcpqFR8aFFiuq3XTvks0uoWjKx3WkAMyjNsxmikg==",
       "dev": true,
       "requires": {
         "@isaacs/ts-node-temp-fork-for-pr-2009": "^10.9.5",
-        "@tapjs/after": "1.1.16",
-        "@tapjs/after-each": "1.1.16",
-        "@tapjs/asserts": "1.1.16",
-        "@tapjs/before": "1.1.16",
-        "@tapjs/before-each": "1.1.16",
-        "@tapjs/filter": "1.2.16",
-        "@tapjs/fixture": "1.2.16",
-        "@tapjs/intercept": "1.2.16",
-        "@tapjs/mock": "1.2.14",
-        "@tapjs/node-serialize": "1.2.5",
-        "@tapjs/snapshot": "1.2.16",
-        "@tapjs/spawn": "1.1.16",
-        "@tapjs/stdin": "1.1.16",
-        "@tapjs/typescript": "1.3.5",
-        "@tapjs/worker": "1.1.16",
+        "@tapjs/after": "1.1.18",
+        "@tapjs/after-each": "1.1.18",
+        "@tapjs/asserts": "1.1.18",
+        "@tapjs/before": "1.1.18",
+        "@tapjs/before-each": "1.1.18",
+        "@tapjs/filter": "1.2.18",
+        "@tapjs/fixture": "1.2.18",
+        "@tapjs/intercept": "1.2.18",
+        "@tapjs/mock": "1.3.0",
+        "@tapjs/node-serialize": "1.3.0",
+        "@tapjs/snapshot": "1.2.18",
+        "@tapjs/spawn": "1.1.18",
+        "@tapjs/stdin": "1.1.18",
+        "@tapjs/typescript": "1.4.0",
+        "@tapjs/worker": "1.1.18",
         "glob": "^10.3.10",
         "jackspeak": "^2.3.6",
         "mkdirp": "^3.0.0",
@@ -24957,18 +27285,18 @@
       }
     },
     "@tapjs/typescript": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@tapjs/typescript/-/typescript-1.3.5.tgz",
-      "integrity": "sha512-LoOHEJ1Bx3MWnh4+uIBXVobxkYNwFzJVnzl1tsLuX0jgGBIGtvmFwXDoM9MtcmO5m8WMZL9bMDT1NWPtcO0V6w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@tapjs/typescript/-/typescript-1.4.0.tgz",
+      "integrity": "sha512-3b3pNI20Cf9NRMuT6GE288RESMYMcrwrKuj29Mroiy9MkLEyyPPHqeSRstvakn9/i/nhTlXj2YIftPo80H3OlQ==",
       "dev": true,
       "requires": {
         "@isaacs/ts-node-temp-fork-for-pr-2009": "^10.9.5"
       }
     },
     "@tapjs/worker": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@tapjs/worker/-/worker-1.1.16.tgz",
-      "integrity": "sha512-BVXyGnf3PMJ7hnwIgaheSpLESI8E9d95EBi8Ni/L3sObbxYR3xIPnhiwCEUCQOp6pkeo8z04T7nJdbQW3dslIA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@tapjs/worker/-/worker-1.1.18.tgz",
+      "integrity": "sha512-wxl/dXByMWk9FuYiiSzY/U5QU0oe9EWpf7pJ48feWsTTn42wihUHZT25kbleR4V2l68/SlTPlJkEsKnHjU27Pg==",
       "dev": true,
       "requires": {}
     },
@@ -25834,9 +28162,9 @@
       "dev": true
     },
     "cacache": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.0.tgz",
-      "integrity": "sha512-I7mVOPl3PUCeRub1U8YoGz2Lqv9WOBpobZ8RyWFXmReuILz+3OAyTa5oH3QPdtKZD7N0Yk00aLfzn0qvp8dZ1w==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.2.tgz",
+      "integrity": "sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==",
       "dev": true,
       "requires": {
         "@npmcli/fs": "^3.1.0",
@@ -25844,7 +28172,7 @@
         "glob": "^10.2.2",
         "lru-cache": "^10.0.1",
         "minipass": "^7.0.3",
-        "minipass-collect": "^1.0.2",
+        "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^4.0.0",
@@ -25867,9 +28195,9 @@
           }
         },
         "lru-cache": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+          "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
           "dev": true
         },
         "p-map": {
@@ -27833,9 +30161,9 @@
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ=="
     },
     "ignore-walk": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.3.tgz",
-      "integrity": "sha512-C7FfFoTA+bI10qfeydT8aZbvr91vAEU+2W5BZUlzPec47oNb07SsOfwYrtxuvOYdUApPP/Qlh4DtAO51Ekk2QA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.4.tgz",
+      "integrity": "sha512-t7sv42WkwFkyKbivUCglsQW5YWMskWtbEf4MNKX5u/CCWHKSPzN4FtBQGsQZgCLbxOzpVlcbWVK5KB3auIOjSw==",
       "dev": true,
       "requires": {
         "minimatch": "^9.0.0"
@@ -28442,9 +30770,9 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "istanbul-lib-coverage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.1.tgz",
-      "integrity": "sha512-opCrKqbthmq3SKZ10mFMQG9dk3fTa3quaOLD35kJa5ejwZHd9xAr+kLuziiZz2cG32s4lMZxNdmdcEQnTDP4+g==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true
     },
     "istanbul-lib-report": {
@@ -28934,23 +31262,12 @@
       "dev": true
     },
     "minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
       "dev": true,
       "requires": {
-        "minipass": "^3.0.0"
-      },
-      "dependencies": {
-        "minipass": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        }
+        "minipass": "^7.0.3"
       }
     },
     "minipass-fetch": {
@@ -29464,20 +31781,20 @@
           }
         },
         "lru-cache": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+          "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
           "dev": true
         }
       }
     },
     "npm-packlist": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.0.tgz",
-      "integrity": "sha512-ErAGFB5kJUciPy1mmx/C2YFbvxoJ0QJ9uwkCZOeR6CqLLISPZBOiFModAbSXnjjlwW5lOhuhXva+fURsSGJqyw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-8.0.2.tgz",
+      "integrity": "sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==",
       "dev": true,
       "requires": {
-        "ignore-walk": "^6.0.0"
+        "ignore-walk": "^6.0.4"
       }
     },
     "npm-pick-manifest": {
@@ -29792,9 +32109,9 @@
       }
     },
     "pacote": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-17.0.4.tgz",
-      "integrity": "sha512-eGdLHrV/g5b5MtD5cTPyss+JxOlaOloSMG3UwPMAvL8ywaLJ6beONPF40K4KKl/UI6q5hTKCJq5rCu8tkF+7Dg==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-17.0.6.tgz",
+      "integrity": "sha512-cJKrW21VRE8vVTRskJo78c/RCvwJCn1f4qgfxL4w77SOWrTCRcmfkYHlHtS0gqpgjv3zhXflRtgsrUCX5xwNnQ==",
       "dev": true,
       "requires": {
         "@npmcli/git": "^5.0.0",
@@ -29812,7 +32129,7 @@
         "promise-retry": "^2.0.1",
         "read-package-json": "^7.0.0",
         "read-package-json-fast": "^3.0.0",
-        "sigstore": "^2.0.0",
+        "sigstore": "^2.2.0",
         "ssri": "^10.0.0",
         "tar": "^6.1.11"
       }
@@ -29903,9 +32220,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+          "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
           "dev": true
         }
       }
@@ -30246,15 +32563,15 @@
           }
         },
         "json-parse-even-better-errors": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
-          "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
+          "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
           "dev": true
         },
         "lru-cache": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+          "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
           "dev": true
         },
         "normalize-package-data": {
@@ -30282,9 +32599,9 @@
       },
       "dependencies": {
         "json-parse-even-better-errors": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
-          "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
+          "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
           "dev": true
         }
       }
@@ -30667,15 +32984,17 @@
       "dev": true
     },
     "sigstore": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.1.0.tgz",
-      "integrity": "sha512-kPIj+ZLkyI3QaM0qX8V/nSsweYND3W448pwkDgS6CQ74MfhEkIR8ToK5Iyx46KJYRjseVcD3Rp9zAmUAj6ZjPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-2.2.0.tgz",
+      "integrity": "sha512-fcU9clHwEss2/M/11FFM8Jwc4PjBgbhXoNskoK5guoK0qGQBSeUbQZRJ+B2fDFIvhyf0gqCaPrel9mszbhAxug==",
       "dev": true,
       "requires": {
-        "@sigstore/bundle": "^2.1.0",
+        "@sigstore/bundle": "^2.1.1",
+        "@sigstore/core": "^0.2.0",
         "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/sign": "^2.1.0",
-        "@sigstore/tuf": "^2.1.0"
+        "@sigstore/sign": "^2.2.1",
+        "@sigstore/tuf": "^2.3.0",
+        "@sigstore/verify": "^0.1.0"
       }
     },
     "sinon": {
@@ -31249,29 +33568,29 @@
       }
     },
     "tap": {
-      "version": "18.5.7",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-18.5.7.tgz",
-      "integrity": "sha512-H2QstHSCmEQAriaPZw5j5DzfASpf15fPVn3a2Vc2TxJ0sahTJo5L7KIihInO6MsrEwGHpQU53u1lB7u8F6QZwg==",
+      "version": "18.7.0",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-18.7.0.tgz",
+      "integrity": "sha512-bL/0krlx8k3fY9mjI9CMfVoAGclZegl+vm5pEJpF/USxam5eNhp5wLk5UH0ST3gWEJkW0PDdFHTOStE+mYurrQ==",
       "dev": true,
       "requires": {
-        "@tapjs/after": "1.1.16",
-        "@tapjs/after-each": "1.1.16",
-        "@tapjs/asserts": "1.1.16",
-        "@tapjs/before": "1.1.16",
-        "@tapjs/before-each": "1.1.16",
-        "@tapjs/core": "1.4.5",
-        "@tapjs/filter": "1.2.16",
-        "@tapjs/fixture": "1.2.16",
-        "@tapjs/intercept": "1.2.16",
-        "@tapjs/mock": "1.2.14",
-        "@tapjs/node-serialize": "1.2.5",
-        "@tapjs/run": "1.4.14",
-        "@tapjs/snapshot": "1.2.16",
-        "@tapjs/spawn": "1.1.16",
-        "@tapjs/stdin": "1.1.16",
-        "@tapjs/test": "1.3.16",
-        "@tapjs/typescript": "1.3.5",
-        "@tapjs/worker": "1.1.16",
+        "@tapjs/after": "1.1.18",
+        "@tapjs/after-each": "1.1.18",
+        "@tapjs/asserts": "1.1.18",
+        "@tapjs/before": "1.1.18",
+        "@tapjs/before-each": "1.1.18",
+        "@tapjs/core": "1.5.0",
+        "@tapjs/filter": "1.2.18",
+        "@tapjs/fixture": "1.2.18",
+        "@tapjs/intercept": "1.2.18",
+        "@tapjs/mock": "1.3.0",
+        "@tapjs/node-serialize": "1.3.0",
+        "@tapjs/run": "1.5.0",
+        "@tapjs/snapshot": "1.2.18",
+        "@tapjs/spawn": "1.1.18",
+        "@tapjs/stdin": "1.1.18",
+        "@tapjs/test": "1.4.0",
+        "@tapjs/typescript": "1.4.0",
+        "@tapjs/worker": "1.1.18",
         "resolve-import": "^1.4.5"
       }
     },
@@ -31344,9 +33663,9 @@
       }
     },
     "tcompare": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-6.4.4.tgz",
-      "integrity": "sha512-mvv9apveoY+XFP2CO2xF3Mkz/v+itzV9ZlhcDY+chIpFGYeTEgiCYdFUPynPme82kNU7UweuxDBQ5J6FkVox/Q==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-6.4.5.tgz",
+      "integrity": "sha512-Whuz9xlKKI2XXICKDSDRKjXdBuC6gBNOgmEUtH7UFyQeYzfUMQ19DyjZULarGKDGFhgOg3CJ+IQUEfpkOPg0Uw==",
       "dev": true,
       "requires": {
         "diff": "^5.1.0",
@@ -31555,9 +33874,9 @@
       }
     },
     "tshy": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tshy/-/tshy-1.8.0.tgz",
-      "integrity": "sha512-Lg2hVO+B8pdNYvBUSgcra4ULlFCcBIkd7ZJ3nRIPvEjplgEscNSwnOzpIMzKW1m17AYhEGcy1nzv7mA3fi/oEQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/tshy/-/tshy-1.11.0.tgz",
+      "integrity": "sha512-5T5PVyuYQKTcOKz5a2lpwx4WKi8yEzQGO0Q5l+9clJMYupMaTI7ONEwKggGAZDQQGIgCOyUCfBWnSkG0XdJc+A==",
       "dev": true,
       "requires": {
         "chalk": "^5.3.0",
@@ -31567,7 +33886,7 @@
         "resolve-import": "^1.4.4",
         "rimraf": "^5.0.1",
         "sync-content": "^1.0.2",
-        "typescript": "5.2",
+        "typescript": "5.2 || 5.3",
         "walk-up-path": "^3.0.1"
       },
       "dependencies": {
@@ -31606,9 +33925,9 @@
           }
         },
         "typescript": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+          "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
           "dev": true
         }
       }
@@ -31735,9 +34054,9 @@
       }
     },
     "tuf-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.1.0.tgz",
-      "integrity": "sha512-eD7YPPjVlMzdggrOeE8zwoegUaG/rt6Bt3jwoQPunRiNVzgcCE009UDFJKJjG+Gk9wFu6W/Vi+P5d/5QpdD9jA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.2.0.tgz",
+      "integrity": "sha512-ZSDngmP1z6zw+FIkIBjvOp/II/mIub/O7Pp12j1WNsiCpg5R5wAc//i555bBQsE44O94btLt0xM/Zr2LQjwdCg==",
       "dev": true,
       "requires": {
         "@tufjs/models": "2.0.0",
@@ -31984,9 +34303,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
-      "integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -31995,9 +34314,9 @@
       },
       "dependencies": {
         "@jridgewell/trace-mapping": {
-          "version": "0.3.20",
-          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-          "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+          "version": "0.3.22",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+          "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
           "dev": true,
           "requires": {
             "@jridgewell/resolve-uri": "^3.1.0",
@@ -32260,9 +34579,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -497,6 +497,7 @@
       "devDependencies": {
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/shared-types": "^0.2.4",
+        "aws-sdk-client-mock": "^3.0.1",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
       }
@@ -6815,41 +6816,41 @@
       }
     },
     "node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "node_modules/@sinonjs/samsam": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
-      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
         "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
       }
     },
     "node_modules/@sinonjs/text-encoding": {
@@ -9200,13 +9201,13 @@
       }
     },
     "node_modules/aws-sdk-client-mock": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-3.0.0.tgz",
-      "integrity": "sha512-4mBiWhuLYLZe1+K/iB8eYy5SAZyW2se+Keyh5u9QouMt6/qJ5SRZhss68xvUX5g3ApzROJ06QPRziYHP6buuvQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-3.0.1.tgz",
+      "integrity": "sha512-9VAzJLl8mz99KP9HjOm/93d8vznRRUTpJooPBOunRdUAnVYopCe9xmMuu7eVemu8fQ+w6rP7o5bBK1kAFkB2KQ==",
       "dev": true,
       "dependencies": {
         "@types/sinon": "^10.0.10",
-        "sinon": "^14.0.2",
+        "sinon": "^16.1.3",
         "tslib": "^2.1.0"
       }
     },
@@ -13187,9 +13188,9 @@
       ]
     },
     "node_modules/just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "dev": true
     },
     "node_modules/keyv": {
@@ -13825,34 +13826,25 @@
       }
     },
     "node_modules/nise": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
-      "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.7.tgz",
+      "integrity": "sha512-wWtNUhkT7k58uvWTB/Gy26eA/EJKtPZFVAhEilN5UYVmmGRYOURbejRUyKm0Uu9XVEW7K5nBOZfR8VMB4QR2RQ==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/text-encoding": "^0.7.2",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^6.2.1"
       }
     },
     "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
       }
     },
     "node_modules/no-case": {
@@ -14821,18 +14813,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/path-to-regexp/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -15931,17 +15914,16 @@
       }
     },
     "node_modules/sinon": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
-      "integrity": "sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==",
-      "deprecated": "16.1.1",
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-16.1.3.tgz",
+      "integrity": "sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@sinonjs/samsam": "^7.0.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.2",
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.3.0",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
         "supports-color": "^7.2.0"
       },
       "funding": {
@@ -22794,6 +22776,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.2.2",
         "@infrascan/shared-types": "^0.2.4",
+        "aws-sdk-client-mock": "^3.0.1",
         "eslint-config-codegen": "^1.0.0",
         "tsconfig": "^0.0.0"
       },
@@ -23913,43 +23896,43 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
-      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.6",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-          "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
+        "@sinonjs/commons": "^3.0.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
-      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
         "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        }
       }
     },
     "@sinonjs/text-encoding": {
@@ -25657,13 +25640,13 @@
       "dev": true
     },
     "aws-sdk-client-mock": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-3.0.0.tgz",
-      "integrity": "sha512-4mBiWhuLYLZe1+K/iB8eYy5SAZyW2se+Keyh5u9QouMt6/qJ5SRZhss68xvUX5g3ApzROJ06QPRziYHP6buuvQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-3.0.1.tgz",
+      "integrity": "sha512-9VAzJLl8mz99KP9HjOm/93d8vznRRUTpJooPBOunRdUAnVYopCe9xmMuu7eVemu8fQ+w6rP7o5bBK1kAFkB2KQ==",
       "dev": true,
       "requires": {
         "@types/sinon": "^10.0.10",
-        "sinon": "^14.0.2",
+        "sinon": "^16.1.3",
         "tslib": "^2.1.0"
       }
     },
@@ -28665,9 +28648,9 @@
       "dev": true
     },
     "just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "dev": true
     },
     "keyv": {
@@ -29165,36 +29148,25 @@
       "dev": true
     },
     "nise": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
-      "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.7.tgz",
+      "integrity": "sha512-wWtNUhkT7k58uvWTB/Gy26eA/EJKtPZFVAhEilN5UYVmmGRYOURbejRUyKm0Uu9XVEW7K5nBOZfR8VMB4QR2RQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/text-encoding": "^0.7.2",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^6.2.1"
       },
       "dependencies": {
         "@sinonjs/fake-timers": {
-          "version": "10.3.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-          "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+          "version": "11.2.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+          "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
           "dev": true,
           "requires": {
             "@sinonjs/commons": "^3.0.0"
-          },
-          "dependencies": {
-            "@sinonjs/commons": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-              "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-              "dev": true,
-              "requires": {
-                "type-detect": "4.0.8"
-              }
-            }
           }
         }
       }
@@ -29939,21 +29911,10 @@
       }
     },
     "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-          "dev": true
-        }
-      }
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -30718,16 +30679,16 @@
       }
     },
     "sinon": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
-      "integrity": "sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==",
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-16.1.3.tgz",
+      "integrity": "sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@sinonjs/samsam": "^7.0.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.2",
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.3.0",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
         "supports-color": "^7.2.0"
       },
       "dependencies": {


### PR DESCRIPTION
The EC2 scanner wasn't correctly scanning VPCs and subnets, preventing them from showing in graphs. This update fixes some broken selectors (for both subnets and VPCs) and adds tests to prevent the issue moving forward. It also updates the graphing of VPCs to correctly build a hierarchy of VPC -> Availability Zone -> Subnet.