### PR TITLE
Prefix region id with account to avoid conflicts and make VPCs region bound

### DIFF
--- a/.changeset/gorgeous-seas-agree.md
+++ b/.changeset/gorgeous-seas-agree.md
@@ -1,0 +1,7 @@
+---
+"@infrascan/aws-ec2-scanner": patch
+"@infrascan/core": patch
+"@infrascan/sdk": patch
+---
+
+Add account prefix to region nodes to avoid cross account conflicts. Use common API for formatting nodes in EC2 to prevent orphaned VPC nodes.

--- a/aws-scanners/ec2/test/index.test.ts
+++ b/aws-scanners/ec2/test/index.test.ts
@@ -102,7 +102,7 @@ t.test(
         t.equal(nodes.length, 5);
 
         // Node for VPC found
-        t.ok(nodes.find((node) => node.data.id === testVpcId));
+        t.ok(nodes.find((node) => node.data.id === testVpcId && node.data.parent === `${testContext.account}-${testContext.region}`));
         // Node for Subnet's AZ found with VPC as parent
         t.ok(nodes.find((node) => node.data.id === `${testVpcId}-${testAZ1}` && node.data.parent === testVpcId));
         t.ok(nodes.find((node) => node.data.id === `${testVpcId}-${testAZ2}` && node.data.parent === testVpcId));

--- a/aws-scanners/ecs/test/index.test.ts
+++ b/aws-scanners/ecs/test/index.test.ts
@@ -117,7 +117,7 @@ t.test(
       // successfully found cluster node
       t.ok(
         nodes.find(
-          (node) => node.id === clusterArn && node.data.type === "ECS-Cluster",
+          (node) => node.id === clusterArn && node.data.type === "ECS-Cluster" && node.data.parent === `${testContext.account}-${testContext.region}`,
         ),
       );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -488,7 +488,7 @@
     },
     "aws-scanners/ec2": {
       "name": "@infrascan/aws-ec2-scanner",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "3.428.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,7 +110,7 @@ function resolveParentForNode(
   context: AwsContext,
   isRegionBound: boolean,
 ): string {
-  return isRegionBound ? context.region : context.account;
+  return isRegionBound ? `${context.account}-${context.region}` : context.account;
 }
 
 export function formatNode(

--- a/packages/sdk/src/graph.ts
+++ b/packages/sdk/src/graph.ts
@@ -56,9 +56,9 @@ export function buildRegionNode(account: string, region: string): GraphNode {
   const humanReadableRegionName = `${region} (${account})`;
   return {
     group: "nodes",
-    id: region,
+    id: `${account}-${region}`,
     data: {
-      id: region,
+      id: `${account}-${region}`,
       type: AWS_REGION_SERVICE_KEY,
       parent: account,
       name: humanReadableRegionName,


### PR DESCRIPTION
The ID for a region was set as the region name, which will result in conflicts in multi account setups. 

EC2 VPCs were orphaned - update EC2 grapher to use common `formatNode` API to correctly resolve parent.