### PR TITLE
Fix: expose all getters for kinesis

### DIFF
--- a/.changeset/giant-jobs-kiss.md
+++ b/.changeset/giant-jobs-kiss.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/aws-kinesis-scanner": patch
+---
+
+Export missing getter for kinesis scanner to include Describe Stream Summary command.

--- a/aws-scanners/kinesis/src/index.ts
+++ b/aws-scanners/kinesis/src/index.ts
@@ -1,7 +1,11 @@
 import { KinesisClient } from "@aws-sdk/client-kinesis";
 import type { ServiceModule } from "@infrascan/shared-types";
 import { getClient } from "./generated/client";
-import { ListStreams, ListStreamConsumers } from "./generated/getters";
+import {
+  DescribeStreamSummary,
+  ListStreams,
+  ListStreamConsumers,
+} from "./generated/getters";
 import { getEdges } from "./generated/graph";
 import { KinesisConsumerEntity, KinesisStreamEntity } from "./graph";
 
@@ -11,7 +15,7 @@ const KinesisScanner: ServiceModule<KinesisClient, "aws"> = {
   key: "Kinesis",
   getClient,
   callPerRegion: true,
-  getters: [ListStreams, ListStreamConsumers],
+  getters: [DescribeStreamSummary, ListStreams, ListStreamConsumers],
   getEdges,
   entities: [KinesisConsumerEntity, KinesisStreamEntity],
 };

--- a/aws-scanners/kinesis/src/index.ts
+++ b/aws-scanners/kinesis/src/index.ts
@@ -15,7 +15,7 @@ const KinesisScanner: ServiceModule<KinesisClient, "aws"> = {
   key: "Kinesis",
   getClient,
   callPerRegion: true,
-  getters: [DescribeStreamSummary, ListStreams, ListStreamConsumers],
+  getters: [ListStreams, DescribeStreamSummary, ListStreamConsumers],
   getEdges,
   entities: [KinesisConsumerEntity, KinesisStreamEntity],
 };


### PR DESCRIPTION
Kinesis scanner didn't expose the describe stream summary getter but depended on it for graph generation.