### PR TITLE
feat: add type to graphs in cytoscape serializer

### DIFF
--- a/packages/cytoscape-serializer/src/index.ts
+++ b/packages/cytoscape-serializer/src/index.ts
@@ -68,6 +68,7 @@ export function serializeGraph(graph: Graph): CytoscapeGraph[] {
         id: node.$graph.id,
         parent: node.$graph.parent ?? defaultParent,
         name: node.$graph.label,
+        type: node.$graph.nodeType,
       }),
     };
   });


### PR DESCRIPTION
type is needed to correctly assign icons to nodes in the graph