### PR TITLE
Improve ECS task labelling

### DIFF
--- a/.changeset/four-boxes-listen.md
+++ b/.changeset/four-boxes-listen.md
@@ -1,0 +1,6 @@
+---
+"@infrascan/aws-ecs-scanner": minor
+"@infrascan/shared-types": patch
+---
+
+Update ECS Task scans to more appropriately label the task nodes, and correct their parent assignment. This release also captures context from the ECS task's attached network interface.

--- a/packages/shared-types/src/scan.ts
+++ b/packages/shared-types/src/scan.ts
@@ -218,6 +218,11 @@ export interface Network {
     instanceTenancy?: string;
     default?: boolean;
   };
+
+  attachedEni?: {
+    interfaceId?: string;
+    macAddress?: string;
+  };
 }
 
 /**


### PR DESCRIPTION
ECS tasks aren't being labelled correctly currently, leading useless nodes in the graph. Updated to use task definition info to create the labels.

Parent relationship for tasks is being pulled from the task details.

Updated graph components to capture details of attached ENIs