### PR TITLE
Correct S3 connector implementation of Connector interface

### DIFF
--- a/.changeset/heavy-lizards-destroy.md
+++ b/.changeset/heavy-lizards-destroy.md
@@ -1,0 +1,6 @@
+---
+"@infrascan/s3-connector": patch
+"@infrascan/shared-types": patch
+---
+
+Improve typescript interfaces — correct api for s3 connector to better adhere to interface, tidy up type imports for shared types lib

--- a/packages/s3-connector/src/index.ts
+++ b/packages/s3-connector/src/index.ts
@@ -5,6 +5,7 @@ import {
   GetObjectCommand,
   ListObjectsV2Command,
 } from "@aws-sdk/client-s3";
+import type { Connector } from "@infrascan/shared-types";
 import Cache from "./cache";
 
 export interface ConstructorArgs {
@@ -17,7 +18,7 @@ export interface ConstructorArgs {
 const isNotNull = <T>(value: T | null | undefined | void): value is T =>
   value != null;
 
-export default class S3Connector {
+export default class S3Connector implements Connector {
   S3: S3Client;
 
   prefix: string;
@@ -77,20 +78,20 @@ export default class S3Connector {
     return `${this.prefix}/${service}-${functionName}/${account}/${region}.json`;
   }
 
-  onServiceScanCompleteCallback(
+  async onServiceScanCompleteCallback(
     account: string,
     region: string,
     service: string,
     functionName: string,
     functionState: any,
-  ): Promise<PutObjectCommandOutput> {
+  ): Promise<void> {
     const filePath = this.buildFilePathForServiceCall(
       account,
       region,
       service,
       functionName,
     );
-    return this.recordServiceCall(filePath, functionState);
+    await this.recordServiceCall(filePath, functionState);
   }
 
   resolveStateForServiceFunction(

--- a/packages/shared-types/src/graph.ts
+++ b/packages/shared-types/src/graph.ts
@@ -1,4 +1,4 @@
-import { BaseState } from "./scan";
+import type { BaseState } from "./scan";
 
 /**
  * A node returned from a state selector before its been formatted for a graphing library

--- a/packages/shared-types/src/plugins.ts
+++ b/packages/shared-types/src/plugins.ts
@@ -1,5 +1,5 @@
-import { Graph } from "./graph";
-import { AwsContext } from "./api";
+import type { Graph } from "./graph";
+import type { AwsContext } from "./api";
 
 // All supported events to trigger a plugin
 export type GraphPluginEvents =

--- a/packages/shared-types/src/scan.ts
+++ b/packages/shared-types/src/scan.ts
@@ -1,4 +1,4 @@
-import { AwsContext, Connector } from "./api";
+import type { AwsContext, Connector } from "./api";
 
 export interface CommandCallMetadata {
   account: string;

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "baseUrl": "src",
     "noEmit": true,
-    "module": "Node16"
+    "module": "Node16",
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
S3 connector returned the PutObject result from the Connector interface which isn't supported.