### PR TITLE
Support custom retry strategy within scans

### DIFF
--- a/.changeset/gorgeous-wasps-camp.md
+++ b/.changeset/gorgeous-wasps-camp.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/sdk": patch
+---
+
+Support configuring a custom retry strategy. Remove concurrent iam api calls.


### PR DESCRIPTION
Add support for passing a custom retry strategy during a scan to reduce risk of rate limiting for larger accounts.

Remove dangerous use of `Promise.all` on iam role scans to avoid hitting rate limits. Include rate limiting strategy for iam client.