### PR TITLE
Correct parent for s3 nodes

### DIFF
--- a/.changeset/plenty-mayflies-give.md
+++ b/.changeset/plenty-mayflies-give.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/aws-s3-scanner": patch
+---
+
+Move S3 from region scope into global account scope in graph output.

--- a/aws-scanners/s3/src/graph.ts
+++ b/aws-scanners/s3/src/graph.ts
@@ -56,7 +56,7 @@ export const S3Entity: TranslatedEntity<
         id: `arn:aws:s3:::${val.Name!}`,
         label: val.Name!,
         nodeType: S3Entity.nodeType,
-        parent: `${val.$metadata.account}-${val.$metadata.region}`,
+        parent: val.$metadata.account,
       };
     },
 

--- a/aws-scanners/s3/src/index.test.ts
+++ b/aws-scanners/s3/src/index.test.ts
@@ -115,6 +115,7 @@ t.test(
       for await (const node of nodeProducer) {
         ok(node.$graph.id);
         ok(node.$graph.label);
+        equal(node.$graph.parent, testContext.account);
         ok(node.$metadata.version);
         equal(node.tenant.tenantId, testContext.account);
         equal(node.tenant.provider, "aws");


### PR DESCRIPTION
S3 nodes were incorrectly placed within the regions in the account, while being global nodes. This caused them to be ignored during graphing.

Correct parent for S3 nodes.