### PR TITLE
Add improved route53 matching logic and correct ECS load balancer location

### DIFF
--- a/.changeset/gorgeous-flies-care.md
+++ b/.changeset/gorgeous-flies-care.md
@@ -2,4 +2,11 @@
 "@infrascan/aws-ecs-scanner": patch
 ---
 
-Move load balancer type under ecs service object as it is not a truly generic load balancer type
+**Note: potentially breaking**
+
+Move load balancer type under ecs service object as it is not a truly generic load balancer type.
+
+Previously configured load balancers for an ECS Service would be tracked on the service node at the top level (i.e. `node.loadBalancer`).
+The `loadBalancer` value contained ECS specific information, and was not linked with the LB in front of the service outside of a target group arn.
+
+To correct this, the `loadBalancer` property is now under the ecs service object (i.e. `node.ecs.service.loadBalancer`).

--- a/.changeset/gorgeous-flies-care.md
+++ b/.changeset/gorgeous-flies-care.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/aws-ecs-scanner": patch
+---
+
+Move load balancer type under ecs service object as it is not a truly generic load balancer type

--- a/.changeset/spotty-months-deny.md
+++ b/.changeset/spotty-months-deny.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/aws-route53-scanner": minor
+---
+
+Account for manual CNAMEs in route53 matching

--- a/aws-scanners/ecs/src/graph.ts
+++ b/aws-scanners/ecs/src/graph.ts
@@ -240,6 +240,7 @@ export const ServiceEntity: TranslatedEntity<
           },
           controller: val.deploymentController,
         },
+        loadBalancers: val.loadBalancers,
       };
     },
     network(val) {
@@ -270,9 +271,6 @@ export const ServiceEntity: TranslatedEntity<
             ? [{ label: "service-role", arn: val.roleArn }]
             : [],
       };
-    },
-    loadBalancers(val) {
-      return val.loadBalancers;
     },
     tags(val) {
       return val.tags;

--- a/aws-scanners/ecs/src/types.d.ts
+++ b/aws-scanners/ecs/src/types.d.ts
@@ -2,6 +2,7 @@ import type {
   PlacementConstraint,
   PlacementStrategy,
   SchedulingStrategy,
+  LoadBalancer,
 } from "@aws-sdk/client-ecs";
 import type { KVPair } from "@infrascan/shared-types";
 
@@ -109,6 +110,7 @@ export interface Service {
     constraints?: PlacementConstraint[];
   };
   schedulingStrategy?: Lowercase<SchedulingStrategy>;
+  loadBalancers?: LoadBalancer[];
 }
 
 // Network related interfaces


### PR DESCRIPTION
Route 53 matching missed manual CNAMEs due to an aggressive filter.

ECS Load Balancer configs were tracked as a generic LB object despite having ecs specific properties. It has now been moved under the ecs.service object.