### PR TITLE
Remove trailing full stop after cname checks

### DIFF
--- a/.changeset/sweet-flowers-deny.md
+++ b/.changeset/sweet-flowers-deny.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/aws-route53-scanner": patch
+---
+
+Correct CNAME check for domains - remove trailing '.' on known AWS targets

--- a/aws-scanners/route53/src/edges.ts
+++ b/aws-scanners/route53/src/edges.ts
@@ -79,16 +79,16 @@ export async function aggregateRoute53RecordsByConnectedService(
         if (resourceRecord.Value == null) {
           return;
         }
-        if (resourceRecord.Value.includes(".cloudfront.net.")) {
+        if (resourceRecord.Value.includes(".cloudfront.net")) {
           recordsByService.cloudfront.push(standardDnsRecord);
-        } else if (resourceRecord.Value.includes(".elb.amazonaws.com.")) {
+        } else if (resourceRecord.Value.includes(".elb.amazonaws.com")) {
           recordsByService.elb.push(standardDnsRecord);
         } else if (
-          /\.execute-api\.\w+\.amazonaws.com\.$/.test(resourceRecord.Value)
+          /\.execute-api\.\w+\.amazonaws.com$/.test(resourceRecord.Value)
         ) {
           recordsByService.apiGateway.push(standardDnsRecord);
         } else if (
-          /s3-website-\w+\.amazonaws.com\.$/.test(resourceRecord.Value)
+          /s3-website-\w+\.amazonaws.com$/.test(resourceRecord.Value)
         ) {
           recordsByService.s3.push(standardDnsRecord);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "infrascan",
       "workspaces": [
         "apps/*",
         "aws-scanners/*",
@@ -34,7 +33,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@infrascan/cytoscape-serializer": "^0.3.2",
-        "@infrascan/shared-types": "^0.6.1",
+        "@infrascan/shared-types": "^0.6.2",
         "@types/cytoscape": "^3.19.16",
         "typescript": "^5.4.5",
         "vite": "^7.0.0"
@@ -590,7 +589,7 @@
         "ejs": "^3.1.9"
       },
       "devDependencies": {
-        "@infrascan/shared-types": "^0.6.1",
+        "@infrascan/shared-types": "^0.6.2",
         "@infrascan/tsconfig": "*",
         "@types/ejs": "^3.1.5",
         "@types/node": "^20.3.1",
@@ -642,7 +641,7 @@
     },
     "aws-scanners/ecs": {
       "name": "@infrascan/aws-ecs-scanner",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ecs": "3.624.0",
@@ -753,7 +752,7 @@
     },
     "aws-scanners/route53": {
       "name": "@infrascan/aws-route53-scanner",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-route-53": "3.624.0",
@@ -780,7 +779,7 @@
     },
     "aws-scanners/s3": {
       "name": "@infrascan/aws-s3-scanner",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "3.624.0",
@@ -19876,7 +19875,7 @@
     },
     "packages/aws": {
       "name": "@infrascan/aws",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@infrascan/aws-api-gateway-scanner": "^0.4.2",
@@ -19885,12 +19884,12 @@
         "@infrascan/aws-cloudwatch-logs-scanner": "^0.4.2",
         "@infrascan/aws-dynamodb-scanner": "^0.4.2",
         "@infrascan/aws-ec2-scanner": "^0.4.1",
-        "@infrascan/aws-ecs-scanner": "^0.5.1",
+        "@infrascan/aws-ecs-scanner": "^0.5.2",
         "@infrascan/aws-elastic-load-balancing-scanner": "^0.4.2",
         "@infrascan/aws-kinesis-scanner": "^0.3.3",
         "@infrascan/aws-lambda-scanner": "^0.4.2",
         "@infrascan/aws-rds-scanner": "^0.4.2",
-        "@infrascan/aws-route53-scanner": "^0.4.2",
+        "@infrascan/aws-route53-scanner": "^0.5.0",
         "@infrascan/aws-s3-scanner": "^0.4.2",
         "@infrascan/aws-sns-scanner": "^0.4.2",
         "@infrascan/aws-sqs-scanner": "^0.4.3",
@@ -19982,7 +19981,7 @@
     },
     "packages/s3-connector": {
       "name": "@infrascan/s3-connector",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "3.624.0",
@@ -19990,7 +19989,7 @@
       },
       "devDependencies": {
         "@aws-sdk/util-stream-node": "^3.374.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.6.2",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-custom": "*",
         "tap": "^21",
@@ -20000,7 +19999,7 @@
     },
     "packages/sdk": {
       "name": "@infrascan/sdk",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "3.624.0",
@@ -20037,7 +20036,7 @@
     },
     "packages/shared-types": {
       "name": "@infrascan/shared-types",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MPL-2.0",
       "devDependencies": {
         "@aws-sdk/types": "3.609.0",
@@ -24244,12 +24243,12 @@
         "@infrascan/aws-cloudwatch-logs-scanner": "^0.4.2",
         "@infrascan/aws-dynamodb-scanner": "^0.4.2",
         "@infrascan/aws-ec2-scanner": "^0.4.1",
-        "@infrascan/aws-ecs-scanner": "^0.5.1",
+        "@infrascan/aws-ecs-scanner": "^0.5.2",
         "@infrascan/aws-elastic-load-balancing-scanner": "^0.4.2",
         "@infrascan/aws-kinesis-scanner": "^0.3.3",
         "@infrascan/aws-lambda-scanner": "^0.4.2",
         "@infrascan/aws-rds-scanner": "^0.4.2",
-        "@infrascan/aws-route53-scanner": "^0.4.2",
+        "@infrascan/aws-route53-scanner": "^0.5.0",
         "@infrascan/aws-s3-scanner": "^0.4.2",
         "@infrascan/aws-sns-scanner": "^0.4.2",
         "@infrascan/aws-sqs-scanner": "^0.4.3",
@@ -24336,7 +24335,7 @@
     "@infrascan/aws-codegen": {
       "version": "file:aws-scanners/codegen",
       "requires": {
-        "@infrascan/shared-types": "^0.6.1",
+        "@infrascan/shared-types": "^0.6.2",
         "@infrascan/tsconfig": "*",
         "@types/ejs": "^3.1.5",
         "@types/node": "^20.3.1",
@@ -24638,7 +24637,7 @@
       "version": "file:apps/render",
       "requires": {
         "@infrascan/cytoscape-serializer": "^0.3.2",
-        "@infrascan/shared-types": "^0.6.1",
+        "@infrascan/shared-types": "^0.6.2",
         "@types/cytoscape": "^3.19.16",
         "typescript": "^5.4.5",
         "vite": "^7.0.0"
@@ -24874,7 +24873,7 @@
       "requires": {
         "@aws-sdk/client-s3": "3.624.0",
         "@aws-sdk/util-stream-node": "^3.374.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.6.2",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-custom": "*",
         "minimatch": "^9.0.3",


### PR DESCRIPTION
route53 was using a trailing full stop on the aws hostnames being compared against which prevented matches.