### PR TITLE
Fix: extend cytoscape graph interface

### DIFF
--- a/.changeset/wicked-trees-sparkle.md
+++ b/.changeset/wicked-trees-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/cytoscape-serializer": patch
+---
+
+Update cytoscape serializer interface to expose more of the structured node data

--- a/apps/render/src/graph.ts
+++ b/apps/render/src/graph.ts
@@ -9,7 +9,27 @@ type GraphElement = Node | Edge;
 function buildNode(id: string): Node {
   return {
     group: "nodes",
-    data: { id },
+    data: {
+      id,
+      $metadata: {
+        version: "0.0.0",
+        timestamp: Date.now(),
+      },
+      $graph: {
+        id,
+        label: id,
+        nodeType: "generic",
+      },
+      tenant: {
+        provider: "aws",
+        tenantId: "123456789012",
+      },
+      resource: {
+        category: "generic",
+        id,
+        name: id,
+      },
+    },
   };
 }
 

--- a/packages/cytoscape-serializer/src/index.ts
+++ b/packages/cytoscape-serializer/src/index.ts
@@ -1,20 +1,39 @@
-import type { Graph } from "@infrascan/shared-types";
+import type { Graph, Node, Readable } from "@infrascan/shared-types";
+
+interface CytoscapeNodeData
+  extends Omit<
+    Readable<Node>,
+    "parent" | "incomingEdges" | "outgoingEdges" | "children"
+  > {
+  id: string;
+  /**
+   * Parent node (account, region etc)
+   */
+  parent?: string;
+  name?: string;
+  service?: string;
+}
 
 /**
  * A node on the graph in Cytoscape format
  */
-export type CytoscapeNode = {
+export interface CytoscapeNode {
   group: "nodes";
-  data: {
-    id: string;
-    /**
-     * Parent node (account, region etc)
-     */
-    parent?: string;
-    name?: string;
-    service?: string;
-  };
-};
+  data: CytoscapeNodeData;
+}
+
+interface CytoscapeEdgeData {
+  id: string;
+  name: string;
+  /**
+   * Source Node
+   */
+  source: string;
+  /**
+   * Target Node
+   */
+  target: string;
+}
 
 /**
  * An edge connecting two nodes within a graph
@@ -24,18 +43,7 @@ export type CytoscapeEdge = {
   /**
    * Unique ID for the edge
    */
-  data: {
-    id: string;
-    name: string;
-    /**
-     * Source Node
-     */
-    source: string;
-    /**
-     * Target Node
-     */
-    target: string;
-  };
+  data: CytoscapeEdgeData;
 };
 
 /**


### PR DESCRIPTION
Graph interface exposed by the cytoscape graph types didn't include the structured node attributes. Update to extend the base node type.