### PR TITLE
Introduce informational nodes

### DIFF
--- a/.changeset/six-tools-switch.md
+++ b/.changeset/six-tools-switch.md
@@ -1,0 +1,25 @@
+---
+"@infrascan/aws-elastic-load-balancing-scanner": minor
+"@infrascan/informational-serializer": minor
+"@infrascan/aws-cloudwatch-logs-scanner": minor
+"@infrascan/aws-step-function-scanner": minor
+"@infrascan/aws-api-gateway-scanner": minor
+"@infrascan/aws-cloudfront-scanner": minor
+"@infrascan/aws-dynamodb-scanner": minor
+"@infrascan/shared-types": minor
+"@infrascan/aws-kinesis-scanner": minor
+"@infrascan/aws-route53-scanner": minor
+"@infrascan/node-reducer-plugin": minor
+"@infrascan/aws-lambda-scanner": minor
+"@infrascan/aws-ec2-scanner": minor
+"@infrascan/aws-ecs-scanner": minor
+"@infrascan/aws-rds-scanner": minor
+"@infrascan/aws-sns-scanner": minor
+"@infrascan/aws-sqs-scanner": minor
+"@infrascan/aws-s3-scanner": minor
+"@infrascan/cli": minor
+"@infrascan/sdk": minor
+"@infrascan/cytoscape-serializer": patch
+---
+
+Introduce informational node support

--- a/apps/render/src/graph.ts
+++ b/apps/render/src/graph.ts
@@ -18,6 +18,7 @@ function buildNode(id: string): Node {
       $graph: {
         id,
         label: id,
+        nodeClass: "visual",
         nodeType: "generic",
       },
       tenant: {

--- a/aws-scanners/api-gateway/src/graph.ts
+++ b/aws-scanners/api-gateway/src/graph.ts
@@ -47,7 +47,7 @@ export const ApiGatewayEntity: TranslatedEntity<
   State<GetApisCommandOutput, GetApisCommandInput>,
   WithCallContext<Api, GetApisCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "api-gateway",
   provider: "aws",
   command: "GetApis",
@@ -86,6 +86,7 @@ export const ApiGatewayEntity: TranslatedEntity<
       return {
         id: val.ApiEndpoint!,
         label: val.ApiEndpoint!,
+        nodeClass: "visual",
         nodeType: ApiGatewayEntity.nodeType,
         parent: `${val.$metadata.account}-${val.$metadata.region}`,
       };

--- a/aws-scanners/cloudfront/src/graph.ts
+++ b/aws-scanners/cloudfront/src/graph.ts
@@ -32,7 +32,7 @@ export const CloudfrontDistributionEntity: TranslatedEntity<
   State<ListDistributionsCommandOutput, ListDistributionsCommandInput>,
   WithCallContext<DistributionSummary, ListDistributionsCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "cloudfront",
   provider: "aws",
   command: "ListDistributions",
@@ -71,6 +71,7 @@ export const CloudfrontDistributionEntity: TranslatedEntity<
       return {
         id: val.ARN!,
         label: val.DomainName!,
+        nodeClass: "visual",
         nodeType: CloudfrontDistributionEntity.nodeType,
         parent: val.$metadata.account,
       };

--- a/aws-scanners/cloudwatch-logs/src/graph.ts
+++ b/aws-scanners/cloudwatch-logs/src/graph.ts
@@ -32,7 +32,7 @@ export const CloudwatchLogGroupEntity: TranslatedEntity<
   State<DescribeLogGroupsCommandOutput, DescribeLogGroupsCommandInput>,
   WithCallContext<LogGroup, DescribeLogGroupsCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "cloudwatch-logs",
   provider: "aws",
   command: "DescribeLogGroups",
@@ -71,6 +71,7 @@ export const CloudwatchLogGroupEntity: TranslatedEntity<
       return {
         id: (val.logGroupArn ?? val.arn)!,
         label: val.logGroupName!,
+        nodeClass: "visual",
         nodeType: CloudwatchLogGroupEntity.nodeType,
         parent: `${val.$metadata.account}-${val.$metadata.region}`,
       };

--- a/aws-scanners/dynamodb/src/graph.ts
+++ b/aws-scanners/dynamodb/src/graph.ts
@@ -187,7 +187,7 @@ export const DynamoDbTableEntity: TranslatedEntity<
     DescribeTableCommandInput
   >
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "dynamodb",
   provider: "aws",
   command: "DescribeTable",
@@ -255,6 +255,7 @@ export const DynamoDbTableEntity: TranslatedEntity<
       return {
         id: val.TableArn!,
         label: val.TableName!,
+        nodeClass: "visual",
         nodeType: DynamoDbTableEntity.nodeType,
         parent: `${val.$metadata.account}-${val.$metadata.region}`,
       };

--- a/aws-scanners/ec2/config.ts
+++ b/aws-scanners/ec2/config.ts
@@ -4,7 +4,8 @@ import type { ScannerDefinition } from "@infrascan/shared-types";
 export type EC2Functions =
   | "DescribeVpcs"
   | "DescribeAvailabilityZones"
-  | "DescribeSubnets";
+  | "DescribeSubnets"
+  | "DescribeSecurityGroups";
 const CloudWatchLogsScanner: ScannerDefinition<
   "EC2",
   typeof EC2,
@@ -24,9 +25,16 @@ const CloudWatchLogsScanner: ScannerDefinition<
       parameters: [
         {
           Key: "Filters",
-          Selector: "EC2|DescribeVpcs|[]._result[].Vpcs[].VpcId",
+          Selector: "EC2|DescribeVpcs|[]._result.Vpcs[].VpcId",
         },
       ],
+      paginationToken: {
+        request: "NextToken",
+        response: "NextToken",
+      },
+    },
+    {
+      fn: "DescribeSecurityGroups",
       paginationToken: {
         request: "NextToken",
         response: "NextToken",

--- a/aws-scanners/ec2/src/generated/client.ts
+++ b/aws-scanners/ec2/src/generated/client.ts
@@ -6,7 +6,6 @@ import type {
 } from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 import debug from "debug";
-
 const clientDebug = debug("ec2:client");
 
 export function getClient(

--- a/aws-scanners/ec2/src/generated/getters.ts
+++ b/aws-scanners/ec2/src/generated/getters.ts
@@ -1,13 +1,19 @@
 import { resolveFunctionCallParameters } from "@infrascan/core";
+import { EC2Client, EC2ServiceException } from "@aws-sdk/client-ec2";
 import {
-  EC2Client,
-  EC2ServiceException,
   DescribeVpcsCommand,
   DescribeVpcsCommandInput,
   DescribeVpcsCommandOutput,
+} from "@aws-sdk/client-ec2";
+import {
   DescribeSubnetsCommand,
   DescribeSubnetsCommandInput,
   DescribeSubnetsCommandOutput,
+} from "@aws-sdk/client-ec2";
+import {
+  DescribeSecurityGroupsCommand,
+  DescribeSecurityGroupsCommandInput,
+  DescribeSecurityGroupsCommandOutput,
 } from "@aws-sdk/client-ec2";
 import type {
   Connector,
@@ -67,7 +73,7 @@ export async function DescribeSubnets(
   const state: GenericState[] = [];
   getterDebug("Fetching state");
   const resolvers = [
-    { Key: "Filters", Selector: "EC2|DescribeVpcs|[]._result[].Vpcs[].VpcId" },
+    { Key: "Filters", Selector: "EC2|DescribeVpcs|[]._result.Vpcs[].VpcId" },
   ];
   const parameterQueue = (await resolveFunctionCallParameters(
     context.account,
@@ -79,7 +85,7 @@ export async function DescribeSubnets(
     let pagingToken: string | undefined;
     do {
       const preparedParams: DescribeSubnetsCommandInput = parameters;
-      preparedParams.NextToken = pagingToken;
+      preparedParams["NextToken"] = pagingToken;
       try {
         const cmd = new DescribeSubnetsCommand(preparedParams);
         const result: DescribeSubnetsCommandOutput = await client.send(cmd);
@@ -92,7 +98,7 @@ export async function DescribeSubnets(
           _parameters: preparedParams,
           _result: result,
         });
-        pagingToken = result.NextToken;
+        pagingToken = result["NextToken"];
         if (pagingToken != null) {
           getterDebug("Found pagination token in response");
         } else {
@@ -118,6 +124,61 @@ export async function DescribeSubnets(
     context.region,
     "EC2",
     "DescribeSubnets",
+    state,
+  );
+}
+
+export async function DescribeSecurityGroups(
+  client: EC2Client,
+  stateConnector: Connector,
+  context: AwsContext,
+): Promise<void> {
+  const getterDebug = debug("ec2:DescribeSecurityGroups");
+  const state: GenericState[] = [];
+  getterDebug("Fetching state");
+  let pagingToken: string | undefined;
+  do {
+    const preparedParams: DescribeSecurityGroupsCommandInput = {};
+    preparedParams["NextToken"] = pagingToken;
+    try {
+      const cmd = new DescribeSecurityGroupsCommand(preparedParams);
+      const result: DescribeSecurityGroupsCommandOutput = await client.send(
+        cmd,
+      );
+      state.push({
+        _metadata: {
+          account: context.account,
+          region: context.region,
+          timestamp: Date.now(),
+        },
+        _parameters: preparedParams,
+        _result: result,
+      });
+      pagingToken = result["NextToken"];
+      if (pagingToken != null) {
+        getterDebug("Found pagination token in response");
+      } else {
+        getterDebug("No pagination token found in response");
+      }
+    } catch (err: unknown) {
+      if (err instanceof EC2ServiceException) {
+        if (err?.$retryable) {
+          console.log("Encountered retryable error", err);
+        } else {
+          console.log("Encountered unretryable error", err);
+        }
+      } else {
+        console.log("Encountered unexpected error", err);
+      }
+      pagingToken = undefined;
+    }
+  } while (pagingToken != null);
+  getterDebug("Recording state");
+  await stateConnector.onServiceScanCompleteCallback(
+    context.account,
+    context.region,
+    "EC2",
+    "DescribeSecurityGroups",
     state,
   );
 }

--- a/aws-scanners/ec2/src/graph.ts
+++ b/aws-scanners/ec2/src/graph.ts
@@ -3,8 +3,12 @@ import {
   DescribeSecurityGroupsCommandOutput,
   DescribeSubnetsCommandInput,
   DescribeSubnetsCommandOutput,
+  DescribeVpcsCommandInput,
+  DescribeVpcsCommandOutput,
   Subnet as Ec2Subnet,
   SubnetState as Ec2SubnetState,
+  Vpc as Ec2Vpc,
+  VpcState as Ec2VpcState,
   PrivateDnsNameOptionsOnLaunch,
   SecurityGroup,
 } from "@aws-sdk/client-ec2";
@@ -39,6 +43,19 @@ export interface Subnet {
 
 export interface SubnetState extends BaseState<DescribeSubnetsCommandInput> {
   subnet: Subnet;
+}
+
+export interface VpcConfig {
+  isDefault?: boolean;
+  instanceTenancy?: string;
+  state?: Ec2VpcState;
+  enableDnsHostnames?: boolean;
+  enableDnsSupport?: boolean;
+  dhcpOptionsId?: string;
+}
+
+export interface VpcState extends BaseState<DescribeVpcsCommandInput> {
+  vpc: VpcConfig;
 }
 
 export const SubnetEntity: TranslatedEntity<
@@ -312,6 +329,138 @@ export const SecurityGroupEntity: TranslatedEntity<
 
       return {
         rules: networkRules,
+      };
+    },
+  },
+};
+
+export const VpcEntity: TranslatedEntity<
+  VpcState,
+  State<DescribeVpcsCommandOutput, DescribeVpcsCommandInput>,
+  WithCallContext<Ec2Vpc, DescribeVpcsCommandInput>
+> = {
+  version: "0.1.0",
+  debugLabel: "ec2-vpc",
+  provider: "aws",
+  command: "DescribeVpcs",
+  category: "ec2",
+  subcategory: "vpc",
+  nodeType: "ec2-vpc",
+  selector: "EC2|DescribeVpcs|[]",
+
+  getState(stateConnector, context) {
+    return evaluateSelector(
+      context.account,
+      context.region,
+      VpcEntity.selector,
+      stateConnector,
+    );
+  },
+
+  translate(val) {
+    return (
+      val._result.Vpcs?.map((vpc) => ({
+        $parameters: val._parameters,
+        $metadata: val._metadata,
+        ...vpc,
+      })) ?? []
+    );
+  },
+
+  components: {
+    $metadata(val) {
+      return {
+        version: VpcEntity.version,
+        timestamp: val.$metadata.timestamp,
+      };
+    },
+    $graph(val) {
+      return {
+        id: val.VpcId!,
+        label: val.VpcId!,
+        nodeClass: "informational",
+        nodeType: VpcEntity.nodeType,
+        parent: `${val.$metadata.account}-${val.$metadata.region}`,
+      };
+    },
+    tenant(val) {
+      return {
+        tenantId: val.$metadata.account,
+        provider: VpcEntity.provider,
+        partition: val.$metadata.partition,
+      };
+    },
+    resource(val) {
+      return {
+        id: val.VpcId!,
+        name: val.VpcId!,
+        category: VpcEntity.category,
+        subcategory: VpcEntity.subcategory,
+      };
+    },
+    $source(val) {
+      return {
+        command: VpcEntity.command,
+        parameters: val.$parameters,
+      };
+    },
+    location(val) {
+      return {
+        code: val.$metadata.region,
+      };
+    },
+    tags(val) {
+      return val.Tags?.map((tag) => ({
+        key: tag.Key,
+        value: tag.Value,
+      }));
+    },
+
+    vpc(val) {
+      return {
+        state: val.State,
+        isDefault: val.IsDefault,
+        instanceTenancy: val.InstanceTenancy,
+        dhcpOptionsId: val.DhcpOptionsId,
+      };
+    },
+
+    network(val) {
+      const vpcAddresses: ReservedAddresses[] = [];
+      if (val.CidrBlock != null) {
+        vpcAddresses.push({ family: "ipv4", cidrBlock: val.CidrBlock });
+      }
+
+      if (
+        val.CidrBlockAssociationSet != null &&
+        val.CidrBlockAssociationSet.length > 0
+      ) {
+        val.CidrBlockAssociationSet.forEach((ipv4Assoc) => {
+          if (ipv4Assoc.CidrBlock != null) {
+            vpcAddresses.push({
+              family: "ipv4",
+              cidrBlock: ipv4Assoc.CidrBlock,
+            });
+          }
+        });
+      }
+
+      if (
+        val.Ipv6CidrBlockAssociationSet != null &&
+        val.Ipv6CidrBlockAssociationSet.length > 0
+      ) {
+        val.Ipv6CidrBlockAssociationSet.forEach((ipv6Assoc) => {
+          if (ipv6Assoc.Ipv6CidrBlock != null) {
+            vpcAddresses.push({
+              family: "ipv6",
+              cidrBlock: ipv6Assoc.Ipv6CidrBlock,
+            });
+          }
+        });
+      }
+
+      return {
+        reservedAddresses: vpcAddresses,
       };
     },
   },

--- a/aws-scanners/ec2/src/graph.ts
+++ b/aws-scanners/ec2/src/graph.ts
@@ -1,0 +1,318 @@
+import {
+  DescribeSecurityGroupsCommandInput,
+  DescribeSecurityGroupsCommandOutput,
+  DescribeSubnetsCommandInput,
+  DescribeSubnetsCommandOutput,
+  Subnet as Ec2Subnet,
+  SubnetState as Ec2SubnetState,
+  PrivateDnsNameOptionsOnLaunch,
+  SecurityGroup,
+} from "@aws-sdk/client-ec2";
+import { evaluateSelector } from "@infrascan/core";
+import type {
+  AwsContext,
+  BaseState,
+  Connector,
+  IpRange,
+  NetworkRule,
+  ReservedAddresses,
+  State,
+  TranslatedEntity,
+  WithCallContext,
+} from "@infrascan/shared-types";
+
+export interface SubnetOnLaunch {
+  publicIp?: boolean;
+  customerOwnedIp?: boolean;
+  privateDns?: PrivateDnsNameOptionsOnLaunch;
+}
+
+export interface Subnet {
+  outpostArn?: string;
+  isDefault?: boolean;
+  onLaunch?: SubnetOnLaunch;
+  enableDns64?: boolean;
+  state?: Ec2SubnetState;
+  assignIpv6?: boolean;
+  enablLniAtDeviceIndex?: number;
+}
+
+export interface SubnetState extends BaseState<DescribeSubnetsCommandInput> {
+  subnet: Subnet;
+}
+
+export const SubnetEntity: TranslatedEntity<
+  SubnetState,
+  State<DescribeSubnetsCommandOutput, DescribeSubnetsCommandInput>,
+  WithCallContext<Ec2Subnet, DescribeSubnetsCommandInput>
+> = {
+  version: "0.1.0",
+  debugLabel: "ec2-subnet",
+  provider: "aws",
+  command: "DescribeSubnets",
+  category: "ec2",
+  subcategory: "subnet",
+  nodeType: "ec2-subnet",
+  selector: "EC2|DescribeSubnets|[]",
+
+  getState(stateConnector, context) {
+    return evaluateSelector(
+      context.account,
+      context.region,
+      SubnetEntity.selector,
+      stateConnector,
+    );
+  },
+
+  translate(val) {
+    return (
+      val._result.Subnets?.map((subnet) => ({
+        $parameters: val._parameters,
+        $metadata: val._metadata,
+        ...subnet,
+      })) ?? []
+    );
+  },
+
+  components: {
+    $metadata(val) {
+      return {
+        version: SubnetEntity.version,
+        timestamp: val.$metadata.timestamp,
+      };
+    },
+    $graph(val) {
+      return {
+        id: val.SubnetArn!,
+        label: val.SubnetId!,
+        nodeClass: "informational",
+        nodeType: SubnetEntity.nodeType,
+        parent: `${val.$metadata.account}-${val.$metadata.region}`,
+      };
+    },
+    tenant(val) {
+      return {
+        tenantId: val.$metadata.account,
+        provider: SubnetEntity.provider,
+        partition: val.$metadata.partition,
+      };
+    },
+    resource(val) {
+      return {
+        id: val.SubnetArn!,
+        name: val.SubnetId!,
+        category: SubnetEntity.category,
+        subcategory: SubnetEntity.subcategory,
+      };
+    },
+    $source(val) {
+      return {
+        command: SubnetEntity.command,
+        parameters: val.$parameters,
+      };
+    },
+    location(val) {
+      return {
+        code: val.$metadata.region,
+        zone: val.AvailabilityZone != null ? [val.AvailabilityZone] : undefined,
+      };
+    },
+    tags(val) {
+      return val.Tags?.map((tag) => ({
+        key: tag.Key,
+        value: tag.Value,
+      }));
+    },
+
+    subnet(val) {
+      return {
+        state: val.State,
+        isDefault: val.DefaultForAz,
+        onLaunch: {
+          publicIp: val.MapPublicIpOnLaunch,
+          customerOwnedIp: val.MapCustomerOwnedIpOnLaunch,
+          privateDns: val.PrivateDnsNameOptionsOnLaunch,
+        },
+        enableDns64: val.EnableDns64,
+        assignIpv6: val.AssignIpv6AddressOnCreation,
+        enablLniAtDeviceIndex: val.EnableLniAtDeviceIndex,
+      };
+    },
+
+    network(val) {
+      const addresses: ReservedAddresses[] = [];
+      if (val.CidrBlock != null) {
+        addresses.push({ family: "ipv4", cidrBlock: val.CidrBlock });
+      }
+      if (val.CustomerOwnedIpv4Pool != null) {
+        addresses.push({
+          family: "ipv4",
+          cidrBlock: val.CustomerOwnedIpv4Pool,
+        });
+      }
+      if (
+        val.Ipv6CidrBlockAssociationSet != null &&
+        val.Ipv6CidrBlockAssociationSet.length > 0
+      ) {
+        val.Ipv6CidrBlockAssociationSet.forEach((ipv6Assoc) => {
+          if (ipv6Assoc.Ipv6CidrBlock != null) {
+            addresses.push({
+              family: "ipv6",
+              cidrBlock: ipv6Assoc.Ipv6CidrBlock,
+            });
+          }
+        });
+      }
+
+      return {
+        reservedAddresses: addresses,
+        subnet: {
+          ipv6Only: val.Ipv6Native,
+          availableAddressCount: val.AvailableIpAddressCount,
+        },
+      };
+    },
+  },
+};
+
+export const SecurityGroupEntity: TranslatedEntity<
+  BaseState<unknown>,
+  State<
+    DescribeSecurityGroupsCommandOutput,
+    DescribeSecurityGroupsCommandInput
+  >,
+  WithCallContext<SecurityGroup, DescribeSecurityGroupsCommandInput>
+> = {
+  version: "0.1.0",
+  debugLabel: "ec2-security-group",
+  provider: "aws",
+  command: "DescribeSecurityGroups",
+  category: "ec2",
+  subcategory: "security-group",
+  nodeType: "ec2-security-group",
+  selector: "EC2|DescribeSecurityGroups|[]",
+
+  translate(
+    val: State<
+      DescribeSecurityGroupsCommandOutput,
+      DescribeSecurityGroupsCommandInput
+    >,
+  ) {
+    return (
+      val._result.SecurityGroups?.map((group) => ({
+        $metadata: val._metadata,
+        $parameters: val._parameters,
+        ...group,
+      })) ?? []
+    );
+  },
+
+  getState(state: Connector, context: AwsContext) {
+    return evaluateSelector(
+      context.account,
+      context.region,
+      SecurityGroupEntity.selector,
+      state,
+    );
+  },
+  components: {
+    $metadata(val) {
+      return {
+        version: SecurityGroupEntity.version,
+        timestamp: val.$metadata.timestamp,
+      };
+    },
+    $graph(val) {
+      return {
+        id: val.GroupId!,
+        label: val.GroupName!,
+        nodeClass: "informational",
+        nodeType: SecurityGroupEntity.nodeType,
+        parent: `${val.$metadata.account}-${val.$metadata.region}`,
+      };
+    },
+    tenant(val) {
+      return {
+        provider: SecurityGroupEntity.provider,
+        partition: val.$metadata.partition,
+        tenantId: val.$metadata.account,
+      };
+    },
+    resource(val) {
+      return {
+        id: val.GroupId!,
+        name: val.GroupName!,
+        category: SecurityGroupEntity.category,
+        subcategory: SecurityGroupEntity.subcategory,
+        description: val.Description,
+      };
+    },
+    tags(val) {
+      return val.Tags?.map((tag) => ({ key: tag.Key, value: tag.Value }));
+    },
+    $source(val) {
+      return {
+        command: SecurityGroupEntity.command,
+        parameters: val.$parameters,
+      };
+    },
+    location(val) {
+      return {
+        code: val.$metadata.region,
+      };
+    },
+    audit(val) {
+      return {
+        createdBy: val.OwnerId,
+      };
+    },
+    network(val) {
+      const networkRules: NetworkRule[] =
+        val.IpPermissions?.map((rules) => {
+          const ipv4Ranges: IpRange[] =
+            rules.IpRanges?.map((range) => ({
+              family: "ipv4",
+              cidrBlock: range.CidrIp,
+              description: range.Description,
+            })) ?? [];
+
+          const ipv6Ranges: IpRange[] =
+            rules.Ipv6Ranges?.map((range) => ({
+              family: "ipv6",
+              cidrBlock: range.CidrIpv6,
+              description: range.Description,
+            })) ?? [];
+
+          const referencedSecGroups = rules.UserIdGroupPairs?.map(
+            (referencedAcc) => ({
+              description: referencedAcc.Description,
+              securityGroupId: referencedAcc.GroupId,
+              securityGroupName: referencedAcc.GroupName,
+              referencedAccountId: referencedAcc.UserId,
+              referencedVpcId: referencedAcc.VpcId,
+              vpcPeeringStatus: referencedAcc.PeeringStatus,
+              vpcPeeringConnectionId: referencedAcc.VpcPeeringConnectionId,
+            }),
+          );
+
+          return {
+            fromPort: rules.FromPort,
+            toPort: rules.ToPort,
+            protocol: rules.IpProtocol === "-1" ? "ALL" : rules.IpProtocol,
+            permittedIpRanges: ipv4Ranges.concat(ipv6Ranges),
+            awsConfig: {
+              referencedSecurityGroups: referencedSecGroups,
+              prefixLists: rules.PrefixListIds?.map((prefix) => ({
+                prefixListId: prefix.PrefixListId,
+                description: prefix.Description,
+              })),
+            },
+          };
+        }) ?? [];
+
+      return {
+        rules: networkRules,
+      };
+    },
+  },
+};

--- a/aws-scanners/ec2/src/index.ts
+++ b/aws-scanners/ec2/src/index.ts
@@ -6,7 +6,7 @@ import {
   DescribeSubnets,
   DescribeSecurityGroups,
 } from "./generated/getters";
-import { SecurityGroupEntity, SubnetEntity } from "./graph";
+import { SecurityGroupEntity, SubnetEntity, VpcEntity } from "./graph";
 
 const EC2Scanner: ServiceModule<EC2Client, "aws"> = {
   provider: "aws",
@@ -15,9 +15,15 @@ const EC2Scanner: ServiceModule<EC2Client, "aws"> = {
   getClient,
   callPerRegion: true,
   getters: [DescribeVpcs, DescribeSubnets, DescribeSecurityGroups],
-  entities: [SubnetEntity, SecurityGroupEntity],
+  entities: [VpcEntity, SubnetEntity, SecurityGroupEntity],
 };
 
-export type { SubnetState, SubnetOnLaunch, Subnet } from "./graph";
+export type {
+  SubnetState,
+  SubnetOnLaunch,
+  Subnet,
+  VpcState,
+  VpcConfig,
+} from "./graph";
 
 export default EC2Scanner;

--- a/aws-scanners/ec2/src/index.ts
+++ b/aws-scanners/ec2/src/index.ts
@@ -1,7 +1,12 @@
 import { EC2Client } from "@aws-sdk/client-ec2";
 import type { ServiceModule } from "@infrascan/shared-types";
 import { getClient } from "./generated/client";
-import { DescribeVpcs, DescribeSubnets } from "./generated/getters";
+import {
+  DescribeVpcs,
+  DescribeSubnets,
+  DescribeSecurityGroups,
+} from "./generated/getters";
+import { SecurityGroupEntity, SubnetEntity } from "./graph";
 
 const EC2Scanner: ServiceModule<EC2Client, "aws"> = {
   provider: "aws",
@@ -9,8 +14,10 @@ const EC2Scanner: ServiceModule<EC2Client, "aws"> = {
   key: "EC2-Networking",
   getClient,
   callPerRegion: true,
-  getters: [DescribeVpcs, DescribeSubnets],
-  entities: [],
+  getters: [DescribeVpcs, DescribeSubnets, DescribeSecurityGroups],
+  entities: [SubnetEntity, SecurityGroupEntity],
 };
+
+export type { SubnetState, SubnetOnLaunch, Subnet } from "./graph";
 
 export default EC2Scanner;

--- a/aws-scanners/ecs/src/graph.ts
+++ b/aws-scanners/ecs/src/graph.ts
@@ -39,7 +39,7 @@ export const ClusterEntity: TranslatedEntity<
   State<DescribeClustersCommandOutput, DescribeClustersCommandInput>,
   WithCallContext<AwsCluster, DescribeClustersCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "ecs-clusters",
   provider: "aws",
   command: "DescribeClusters",
@@ -75,6 +75,7 @@ export const ClusterEntity: TranslatedEntity<
       return {
         id: val.clusterArn!,
         label: val.clusterName!,
+        nodeClass: "visual",
         nodeType: ClusterEntity.nodeType,
         parent: `${val.$metadata.account}-${val.$metadata.region}`,
       };
@@ -139,7 +140,7 @@ export const ServiceEntity: TranslatedEntity<
   State<DescribeServicesCommandOutput, DescribeServicesCommandInput>,
   WithCallContext<AwsService, DescribeServicesCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "ecs-services",
   provider: "aws",
   command: "DescribeServices",
@@ -172,6 +173,7 @@ export const ServiceEntity: TranslatedEntity<
         id: val.serviceArn!,
         label: val.serviceName!,
         parent: val.clusterArn!,
+        nodeClass: "visual",
         nodeType: ServiceEntity.nodeType,
       };
     },
@@ -243,6 +245,11 @@ export const ServiceEntity: TranslatedEntity<
         loadBalancers: val.loadBalancers,
       };
     },
+
+    loadBalancers(val) {
+      return val.loadBalancers;
+    },
+
     network(val) {
       const publicIpStatus =
         val.networkConfiguration?.awsvpcConfiguration?.assignPublicIp ===
@@ -303,7 +310,7 @@ export const TaskEntity: TranslatedEntity<
   State<DescribeTasksCommandOutput, DescribeTasksCommandInput>,
   WithCallContext<Task, DescribeTasksCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "ecs-tasks",
   provider: "aws",
   command: "DescribeTasks",
@@ -355,6 +362,7 @@ export const TaskEntity: TranslatedEntity<
       return {
         id: val.taskDefinitionArn ?? val.taskArn!,
         label: label!,
+        nodeClass: "visual",
         parent,
         nodeType: TaskEntity.nodeType,
       };

--- a/aws-scanners/elastic-load-balancing/src/graph.ts
+++ b/aws-scanners/elastic-load-balancing/src/graph.ts
@@ -47,7 +47,7 @@ export const ElasticLoadBalancerEntity: TranslatedEntity<
   State<DescribeLoadBalancersCommandOutput, DescribeLoadBalancersCommandInput>,
   WithCallContext<LoadBalancer, DescribeLoadBalancersCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "elastic-load-balancing",
   provider: "aws",
   command: "DescribeLoadBalancers",
@@ -87,6 +87,7 @@ export const ElasticLoadBalancerEntity: TranslatedEntity<
         id: val.LoadBalancerArn!,
         label: val.LoadBalancerName!,
         nodeType: getNodeType(val.Type),
+        nodeClass: "visual",
         parent: `${val.$metadata.account}-${val.$metadata.region}`,
       };
     },

--- a/aws-scanners/kinesis/src/graph.ts
+++ b/aws-scanners/kinesis/src/graph.ts
@@ -42,7 +42,7 @@ export const KinesisStreamEntity: TranslatedEntity<
   State<DescribeStreamSummaryCommandOutput, DescribeStreamSummaryCommandInput>,
   WithCallContext<StreamDescriptionSummary, DescribeStreamSummaryCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "kinesis",
   provider: "aws",
   command: "DescribeStreamSummary",
@@ -86,6 +86,7 @@ export const KinesisStreamEntity: TranslatedEntity<
       return {
         id: val.StreamARN!,
         label: val.StreamName!,
+        nodeClass: "visual",
         nodeType: KinesisStreamEntity.nodeType,
         parent: `${val.$metadata.account}-${val.$metadata.region}`,
       };
@@ -161,7 +162,7 @@ export const KinesisConsumerEntity: TranslatedEntity<
   State<ListStreamConsumersCommandOutput, ListStreamConsumersInput>,
   WithCallContext<Consumer, ListStreamConsumersInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "kinesis",
   provider: "aws",
   command: "ListStreamConsumers",
@@ -200,6 +201,7 @@ export const KinesisConsumerEntity: TranslatedEntity<
       return {
         id: val.ConsumerARN!,
         label: val.ConsumerName!,
+        nodeClass: "informational",
         nodeType: KinesisConsumerEntity.nodeType,
         parent: `${val.$metadata.account}-${val.$metadata.region}`,
       };

--- a/aws-scanners/lambda/config.ts
+++ b/aws-scanners/lambda/config.ts
@@ -1,7 +1,10 @@
 import * as Lambda from "@aws-sdk/client-lambda";
 import type { ScannerDefinition } from "@infrascan/shared-types";
 
-export type LambdaFunctions = "ListFunctions" | "GetFunction";
+export type LambdaFunctions =
+  | "ListFunctions"
+  | "GetFunction"
+  | "ListEventSourceMappings";
 
 const LambdaScanner: ScannerDefinition<
   "Lambda",
@@ -29,6 +32,19 @@ const LambdaScanner: ScannerDefinition<
           Selector: "Lambda|ListFunctions|[]._result.Functions[].FunctionArn",
         },
       ],
+    },
+    {
+      fn: "ListEventSourceMappings",
+      parameters: [
+        {
+          Key: "FunctionName",
+          Selector: "Lambda|ListFunctions|[]._result.Functions[].FunctionArn",
+        },
+      ],
+      paginationToken: {
+        request: "Marker",
+        response: "NextMarker",
+      },
     },
   ],
   iamRoles: [

--- a/aws-scanners/lambda/src/generated/client.ts
+++ b/aws-scanners/lambda/src/generated/client.ts
@@ -6,7 +6,6 @@ import type {
 } from "@aws-sdk/types";
 import type { AwsContext } from "@infrascan/shared-types";
 import debug from "debug";
-
 const clientDebug = debug("lambda:client");
 
 export function getClient(

--- a/aws-scanners/lambda/src/graph.ts
+++ b/aws-scanners/lambda/src/graph.ts
@@ -1,7 +1,19 @@
 import type {
+  AmazonManagedKafkaEventSourceConfig,
+  DestinationConfig,
+  DocumentDBEventSourceConfig,
+  EventSourceMappingConfiguration,
+  EventSourcePosition,
+  FilterCriteria,
   GetFunctionCommandInput,
   GetFunctionCommandOutput,
+  ListEventSourceMappingsCommandInput,
+  ListEventSourceMappingsCommandOutput,
   PackageType,
+  ScalingConfig,
+  SelfManagedEventSource,
+  SelfManagedKafkaEventSourceConfig,
+  SourceAccessConfiguration,
 } from "@aws-sdk/client-lambda";
 import { evaluateSelector, toLowerCase, Size, Time } from "@infrascan/core";
 import type {
@@ -62,7 +74,7 @@ export const LambdaFunctionEntity: TranslatedEntity<
   State<GetFunctionCommandOutput, GetFunctionCommandInput>,
   WithCallContext<GetFunctionCommandOutput, GetFunctionCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "lambda",
   provider: "aws",
   command: "ListFunctions",
@@ -101,6 +113,7 @@ export const LambdaFunctionEntity: TranslatedEntity<
       return {
         id: val.Configuration!.FunctionArn!,
         label: val.Configuration!.FunctionName!,
+        nodeClass: "visual",
         nodeType: LambdaFunctionEntity.nodeType,
         parent: `${val.$metadata.account}-${val.$metadata.region}`,
       };
@@ -244,6 +257,200 @@ export const LambdaFunctionEntity: TranslatedEntity<
         },
         securityGroups: val.Configuration?.VpcConfig?.SecurityGroupIds,
         targetSubnets: val.Configuration?.VpcConfig?.SubnetIds,
+      };
+    },
+  },
+};
+
+export interface EventProducers {
+  managedKafka?: AmazonManagedKafkaEventSourceConfig;
+  selfManagedKafka?: SelfManagedKafkaEventSourceConfig;
+  documentDb?: DocumentDBEventSourceConfig;
+  selfManagedSource?: SelfManagedEventSource;
+  queues?: string[];
+  topics?: string[];
+}
+
+export interface ProcessingConfig {
+  parallelizationFactor?: number;
+  destinationConfig?: DestinationConfig;
+  scaling?: ScalingConfig;
+}
+
+export interface ReaderConfig {
+  filter?: FilterCriteria;
+  batchSize?: number;
+  maximumBatchWindow?: QualifiedMeasure<TimeUnit>;
+  tumblingWindow?: QualifiedMeasure<TimeUnit>;
+  maximumRecordAge?: QualifiedMeasure<TimeUnit>;
+  startingPosition?: EventSourcePosition;
+  startingPositionTimestamp?: string;
+}
+
+export interface EventSourceStatus {
+  state?: string;
+  stateTransitionReason?: string;
+  lastResult?: string;
+}
+
+export interface ErrorHandling {
+  maxRetryAttempts?: number;
+  bisectBatchOnFailure?: boolean;
+}
+
+export interface EventSource {
+  functionArn?: string;
+  sources?: EventProducers;
+  processingConfig?: ProcessingConfig;
+  status?: EventSourceStatus;
+  errorHandling?: ErrorHandling;
+  reader?: ReaderConfig;
+  sourceAccessConfigurations?: SourceAccessConfiguration[];
+}
+
+export interface EventSourceMapping
+  extends BaseState<ListEventSourceMappingsCommandInput> {
+  eventSource: EventSource;
+}
+
+export const LambdaEventSourceEntity: TranslatedEntity<
+  EventSourceMapping,
+  State<
+    ListEventSourceMappingsCommandOutput,
+    ListEventSourceMappingsCommandInput
+  >,
+  WithCallContext<
+    EventSourceMappingConfiguration,
+    ListEventSourceMappingsCommandInput
+  >
+> = {
+  version: "0.1.0",
+  debugLabel: "lambda-event-source",
+  provider: "aws",
+  command: "ListFunctions",
+  category: "lambda",
+  subcategory: "event-source",
+  nodeType: "lambda-event-source",
+  selector: "Lambda|ListEventSourceMappings|[]",
+
+  getState(state, context) {
+    return evaluateSelector(
+      context.account,
+      context.region,
+      LambdaEventSourceEntity.selector,
+      state,
+    );
+  },
+
+  translate(val) {
+    return (
+      val._result.EventSourceMappings?.map((config) => ({
+        ...config,
+        $metadata: val._metadata,
+        $parameters: val._parameters,
+      })) ?? []
+    );
+  },
+
+  components: {
+    $metadata(val) {
+      return {
+        version: LambdaEventSourceEntity.version,
+        timestamp: val.$metadata.timestamp,
+      };
+    },
+
+    $graph(val) {
+      return {
+        id: val.EventSourceArn!,
+        label: val.UUID!,
+        nodeClass: "informational",
+        nodeType: LambdaEventSourceEntity.nodeType,
+        parent: `${val.$metadata.account}-${val.$metadata.region}`,
+      };
+    },
+
+    $source(val) {
+      return {
+        command: LambdaEventSourceEntity.command,
+        parameters: val.$parameters,
+      };
+    },
+
+    tenant(val) {
+      return {
+        tenantId: val.$metadata.account,
+        provider: LambdaEventSourceEntity.provider,
+        partition: val.$metadata.partition,
+      };
+    },
+
+    location(val) {
+      return {
+        code: val.$metadata.region,
+      };
+    },
+
+    resource(val) {
+      return {
+        id: val.EventSourceArn!,
+        name: val.UUID!,
+        category: LambdaEventSourceEntity.category,
+        subcategory: LambdaEventSourceEntity.subcategory,
+      };
+    },
+
+    eventSource(val) {
+      return {
+        functionArn: val.FunctionArn,
+        sources: {
+          managedKafka: val.AmazonManagedKafkaEventSourceConfig,
+          selfManagedKafka: val.SelfManagedKafkaEventSourceConfig,
+          documentDb: val.DocumentDBEventSourceConfig,
+          selfManagedSource: val.SelfManagedEventSource,
+          queues: val.Queues,
+          topics: val.Topics,
+        },
+        processingConfig: {
+          parallelizationFactor: val.ParallelizationFactor,
+          destinationConfig: val.DestinationConfig,
+          scaling: val.ScalingConfig,
+        },
+        status: {
+          state: val.State,
+          stateTransitionReason: val.StateTransitionReason,
+          lastResult: val.LastProcessingResult,
+        },
+        errorHandling: {
+          maxRetryAttempts: val.MaximumRetryAttempts,
+          bisectBatchOnFailure: val.BisectBatchOnFunctionError,
+        },
+        reader: {
+          filter: val.FilterCriteria,
+          batchSize: val.BatchSize,
+          maximumBatchWindow: val.MaximumBatchingWindowInSeconds
+            ? {
+                unit: "s",
+                value: val.MaximumBatchingWindowInSeconds,
+              }
+            : undefined,
+          tumblingWindow: val.TumblingWindowInSeconds
+            ? {
+                unit: "s",
+                value: val.TumblingWindowInSeconds,
+              }
+            : undefined,
+          maximumRecordAge: val.MaximumRecordAgeInSeconds
+            ? {
+                unit: "s",
+                value: val.MaximumRecordAgeInSeconds,
+              }
+            : undefined,
+          startingPosition: val.StartingPosition,
+          startingPositionTimestamp:
+            val.StartingPositionTimestamp?.toISOString(),
+        },
+        sourceAccessConfigurations: val.SourceAccessConfigurations,
       };
     },
   },

--- a/aws-scanners/lambda/src/index.test.ts
+++ b/aws-scanners/lambda/src/index.test.ts
@@ -8,6 +8,7 @@ import { fromProcess } from "@aws-sdk/credential-providers";
 import {
   ListFunctionsCommand,
   GetFunctionCommand,
+  ListEventSourceMappingsCommand,
 } from "@aws-sdk/client-lambda";
 import { generateNodesFromEntity } from "@infrascan/core";
 import buildFsConnector from "@infrascan/fs-connector";
@@ -55,6 +56,10 @@ t.test(
       Code: {
         ImageUri: "hub.docker.com",
       },
+    });
+
+    mockedLambdaClient.on(ListEventSourceMappingsCommand).resolves({
+      EventSourceMappings: [],
     });
 
     for (const scannerFn of LambdaScanner.getters) {

--- a/aws-scanners/lambda/src/index.ts
+++ b/aws-scanners/lambda/src/index.ts
@@ -1,8 +1,13 @@
 import { LambdaClient } from "@aws-sdk/client-lambda";
 import type { ServiceModule } from "@infrascan/shared-types";
-import { ListFunctions, GetFunction, getIamRoles } from "./generated/getters";
+import {
+  ListFunctions,
+  GetFunction,
+  ListEventSourceMappings,
+  getIamRoles,
+} from "./generated/getters";
 import { getClient } from "./generated/client";
-import { LambdaFunctionEntity } from "./graph";
+import { LambdaEventSourceEntity, LambdaFunctionEntity } from "./graph";
 
 const LambdaScanner: ServiceModule<LambdaClient, "aws"> = {
   provider: "aws",
@@ -10,9 +15,9 @@ const LambdaScanner: ServiceModule<LambdaClient, "aws"> = {
   key: "Lambda",
   getClient,
   callPerRegion: true,
-  getters: [ListFunctions, GetFunction],
+  getters: [ListFunctions, GetFunction, ListEventSourceMappings],
   getIamRoles,
-  entities: [LambdaFunctionEntity],
+  entities: [LambdaFunctionEntity, LambdaEventSourceEntity],
 };
 
 export type {
@@ -22,5 +27,12 @@ export type {
   FunctionDetails,
   ConcurrencyDetails,
   Layer,
+  ErrorHandling,
+  EventProducers,
+  EventSource,
+  EventSourceMapping,
+  EventSourceStatus,
+  ReaderConfig,
+  ProcessingConfig,
 } from "./graph";
 export default LambdaScanner;

--- a/aws-scanners/rds/src/graph.ts
+++ b/aws-scanners/rds/src/graph.ts
@@ -44,7 +44,7 @@ export const RDSInstanceEntity: TranslatedEntity<
   State<DescribeDBInstancesCommandOutput, DescribeDBInstancesCommandInput>,
   WithCallContext<DBInstance, DescribeDBInstancesCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "rds",
   provider: "aws",
   command: "DescribeDBInstances",
@@ -84,6 +84,7 @@ export const RDSInstanceEntity: TranslatedEntity<
         id: val.DBInstanceIdentifier!,
         label: val.DBName!,
         nodeType: RDSInstanceEntity.nodeType,
+        nodeClass: "visual",
         parent:
           val.DBClusterIdentifier ??
           `${val.$metadata.account}-${val.$metadata.region}`,

--- a/aws-scanners/route53/src/graph.ts
+++ b/aws-scanners/route53/src/graph.ts
@@ -36,7 +36,7 @@ export const Route53RecordEntity: TranslatedEntity<
   >,
   WithCallContext<ResourceRecordSet, ListResourceRecordSetsCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "route53-record",
   provider: "aws",
   command: "ListResourceRecordSets",
@@ -82,6 +82,7 @@ export const Route53RecordEntity: TranslatedEntity<
       return {
         id: val.Name!,
         label: val.Name!,
+        nodeClass: "visual",
         nodeType: Route53RecordEntity.nodeType,
         parent: val.$metadata.account,
       };

--- a/aws-scanners/s3/src/graph.ts
+++ b/aws-scanners/s3/src/graph.ts
@@ -17,7 +17,7 @@ export const S3Entity: TranslatedEntity<
   State<ListBucketsCommandOutput, ListBucketsCommandInput>,
   WithCallContext<Bucket, ListBucketsCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "s3-bucket",
   provider: "aws",
   command: "ListBuckets",
@@ -55,6 +55,7 @@ export const S3Entity: TranslatedEntity<
       return {
         id: `arn:aws:s3:::${val.Name!}`,
         label: val.Name!,
+        nodeClass: "visual",
         nodeType: S3Entity.nodeType,
         parent: val.$metadata.account,
       };

--- a/aws-scanners/sns/src/index.test.ts
+++ b/aws-scanners/sns/src/index.test.ts
@@ -142,9 +142,12 @@ t.test(
         equal(node.$source?.command, entity.command);
         equal(node.resource.category, entity.category);
         equal(node.resource.subcategory, entity.subcategory);
-        ok(node.resource.policy);
-        ok((node as unknown as SNSEntity).sns);
-        equal((node as unknown as SNSEntity).sns.fifo, false);
+
+        if (node.resource.subcategory === "topic") {
+          ok(node.resource.policy);
+          ok((node as unknown as SNSEntity).sns);
+          equal((node as unknown as SNSEntity).sns.fifo, false);
+        }
       }
     }
   },

--- a/aws-scanners/sns/src/index.ts
+++ b/aws-scanners/sns/src/index.ts
@@ -8,7 +8,7 @@ import {
   ListTagsForResource,
 } from "./generated/getters";
 import { getEdges } from "./generated/graph";
-import { SNSTopicEntity } from "./graph";
+import { SNSSubscriptionEntity, SNSTopicEntity } from "./graph";
 
 const SNSScanner: ServiceModule<SNSClient, "aws"> = {
   provider: "aws",
@@ -23,7 +23,7 @@ const SNSScanner: ServiceModule<SNSClient, "aws"> = {
     ListTagsForResource,
   ],
   getEdges,
-  entities: [SNSTopicEntity],
+  entities: [SNSTopicEntity, SNSSubscriptionEntity],
 };
 
 export type { GraphState, SNS, TopicAttributes } from "./graph";

--- a/aws-scanners/sqs/src/graph.ts
+++ b/aws-scanners/sqs/src/graph.ts
@@ -37,7 +37,7 @@ export const SQSEntity: TranslatedEntity<
   State<GetQueueAttributesCommandOutput, GetQueueAttributesCommandInput>,
   WithCallContext<QueueAttributes, GetQueueAttributesCommandInput>
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "sqs-queue",
   provider: "aws",
   command: "GetQueueAttributes",
@@ -78,6 +78,7 @@ export const SQSEntity: TranslatedEntity<
       return {
         id: val.QueueArn!,
         label: queueName,
+        nodeClass: "visual",
         nodeType: SQSEntity.nodeType,
         parent: `${val.$metadata.account}-${val.$metadata.region}`,
       };

--- a/aws-scanners/step-function/src/graph.ts
+++ b/aws-scanners/step-function/src/graph.ts
@@ -37,7 +37,7 @@ export const StepFunctionEntity: TranslatedEntity<
     DescribeStateMachineCommandInput
   >
 > = {
-  version: "0.1.0",
+  version: "0.1.1",
   debugLabel: "step-function",
   provider: "aws",
   command: "DescribeStateMachine",
@@ -77,6 +77,7 @@ export const StepFunctionEntity: TranslatedEntity<
       return {
         id: val.stateMachineArn!,
         label: val.name!,
+        nodeClass: "visual",
         nodeType: StepFunctionEntity.nodeType,
         parent: `${val.$metadata.account}-${val.$metadata.region}`,
       };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,11 +28,85 @@
         "typescript-eslint": "^8.35.0"
       }
     },
+    "apps/mcp": {
+      "name": "@infrascan/mcp",
+      "version": "0.1.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "@aws-sdk/credential-provider-node": "^3.879.0",
+        "@aws-sdk/credential-providers": "^3.879.0",
+        "@infrascan/cytoscape-serializer": "^0.3.2",
+        "@infrascan/fs-connector": "^0.3.0",
+        "@infrascan/sdk": "^0.5.1",
+        "@modelcontextprotocol/sdk": "^1.17.4",
+        "better-sqlite3": "^9.4.0",
+        "cors": "^2.8.5",
+        "express": "^4.19.2",
+        "kysely": "^0.27.2",
+        "uuid": "^10.0.0",
+        "winston": "^3.13.0",
+        "ws": "^8.17.1",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@infrascan/shared-types": "^0.6.2",
+        "@types/better-sqlite3": "^7.6.8",
+        "@types/cors": "^2.8.17",
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.14.0",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.5.10",
+        "@typescript-eslint/eslint-plugin": "^7.13.0",
+        "@typescript-eslint/parser": "^7.13.0",
+        "eslint": "^8.57.0",
+        "kysely-ctl": "^0.8.0",
+        "tsx": "^4.15.0",
+        "typescript": "^5.4.5"
+      }
+    },
+    "apps/mcp-client": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.61.0",
+        "@modelcontextprotocol/sdk": "^1.17.5",
+        "dotenv": "^17.2.2"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "typescript": "^5.9.2"
+      }
+    },
+    "apps/mcp-server": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "@infrascan/core": "^0.5.0",
+        "@modelcontextprotocol/sdk": "^1.17.5",
+        "cidr-matcher": "^2.1.1",
+        "minimatch": "^10.0.3",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "infrascan-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@infrascan/aws": "^0.5.3",
+        "@infrascan/cytoscape-serializer": "0.3.3",
+        "@infrascan/shared-types": "^0.6.2",
+        "@types/cidr-matcher": "^2.1.2",
+        "@types/node": "^24.3.0",
+        "typescript": "^5.9.2"
+      }
+    },
     "apps/render": {
       "name": "@infrascan/render",
       "version": "0.0.0",
       "devDependencies": {
-        "@infrascan/cytoscape-serializer": "^0.3.2",
+        "@infrascan/cytoscape-serializer": "^0.3.3",
         "@infrascan/shared-types": "^0.6.2",
         "@types/cytoscape": "^3.19.16",
         "typescript": "^5.4.5",
@@ -752,7 +826,7 @@
     },
     "aws-scanners/route53": {
       "name": "@infrascan/aws-route53-scanner",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-route-53": "3.624.0",
@@ -6221,6 +6295,10 @@
       "resolved": "packages/fs-connector",
       "link": true
     },
+    "node_modules/@infrascan/informational-serializer": {
+      "resolved": "packages/informational-serializer",
+      "link": true
+    },
     "node_modules/@infrascan/node-reducer-plugin": {
       "resolved": "plugins/node-reducer",
       "link": true
@@ -9876,12 +9954,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
-      "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/sinon": {
@@ -13148,6 +13227,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/get-uri": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.2.tgz",
@@ -14868,6 +14962,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/jmespath": {
@@ -17146,6 +17251,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -18997,6 +19114,28 @@
         "node": ">= 8"
       }
     },
+    "node_modules/tsx": {
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/tuf-js": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.2.1.tgz",
@@ -19288,10 +19427,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
@@ -19909,6 +20049,7 @@
         "@infrascan/aws": "^0.5.0",
         "@infrascan/cytoscape-serializer": "^0.3.0",
         "@infrascan/fs-connector": "^0.3.0",
+        "@infrascan/informational-serializer": "^0.1.0",
         "@infrascan/sdk": "^0.5.0",
         "@rushstack/ts-command-line": "^4.15.2",
         "@smithy/shared-ini-file-loader": "^2.2.2",
@@ -19959,7 +20100,7 @@
     },
     "packages/cytoscape-serializer": {
       "name": "@infrascan/cytoscape-serializer",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MPL-2.0",
       "devDependencies": {
         "@infrascan/shared-types": "^0.6.0"
@@ -19977,6 +20118,14 @@
         "eslint-config-custom": "*",
         "tsconfig": "*",
         "typescript": "^5.4.5"
+      }
+    },
+    "packages/informational-serializer": {
+      "name": "@infrascan/informational-serializer",
+      "version": "0.1.0",
+      "license": "MPL-2.0",
+      "devDependencies": {
+        "@infrascan/shared-types": "^0.6.0"
       }
     },
     "packages/s3-connector": {
@@ -24572,6 +24721,7 @@
         "@infrascan/aws": "^0.5.0",
         "@infrascan/cytoscape-serializer": "^0.3.0",
         "@infrascan/fs-connector": "^0.3.0",
+        "@infrascan/informational-serializer": "^0.1.0",
         "@infrascan/sdk": "^0.5.0",
         "@infrascan/shared-types": "^0.6.0",
         "@rushstack/ts-command-line": "^4.15.2",
@@ -24622,6 +24772,12 @@
         "typescript": "^5.4.5"
       }
     },
+    "@infrascan/informational-serializer": {
+      "version": "file:packages/informational-serializer",
+      "requires": {
+        "@infrascan/shared-types": "^0.6.0"
+      }
+    },
     "@infrascan/node-reducer-plugin": {
       "version": "file:plugins/node-reducer",
       "requires": {
@@ -24636,7 +24792,7 @@
     "@infrascan/render": {
       "version": "file:apps/render",
       "requires": {
-        "@infrascan/cytoscape-serializer": "^0.3.2",
+        "@infrascan/cytoscape-serializer": "^0.3.3",
         "@infrascan/shared-types": "^0.6.2",
         "@types/cytoscape": "^3.19.16",
         "typescript": "^5.4.5",
@@ -27559,12 +27715,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.12.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
-      "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
       "dev": true,
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/sinon": {
@@ -29762,6 +29918,17 @@
         "get-intrinsic": "^1.2.6"
       }
     },
+    "get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "resolve-pkg-maps": "^1.0.0"
+      }
+    },
     "get-uri": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.2.tgz",
@@ -30896,6 +31063,13 @@
           }
         }
       }
+    },
+    "jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "optional": true,
+      "peer": true
     },
     "jmespath": {
       "version": "0.16.0",
@@ -32519,6 +32693,14 @@
         }
       }
     },
+    "resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -33758,6 +33940,19 @@
         }
       }
     },
+    "tsx": {
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "esbuild": "~0.25.0",
+        "fsevents": "~2.3.3",
+        "get-tsconfig": "^4.7.5"
+      }
+    },
     "tuf-js": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.2.1.tgz",
@@ -33928,9 +34123,9 @@
       }
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "unique-filename": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "@infrascan/aws": "^0.5.0",
     "@infrascan/cytoscape-serializer": "^0.3.0",
     "@infrascan/fs-connector": "^0.3.0",
+    "@infrascan/informational-serializer": "^0.1.0",
     "@infrascan/sdk": "^0.5.0",
     "@rushstack/ts-command-line": "^4.15.2",
     "@smithy/shared-ini-file-loader": "^2.2.2",

--- a/packages/cytoscape-serializer/src/index.ts
+++ b/packages/cytoscape-serializer/src/index.ts
@@ -57,37 +57,39 @@ export type EdgeTarget = {
 };
 
 export function serializeGraph(graph: Graph): CytoscapeGraph[] {
-  const nodes: CytoscapeNode[] = graph.nodes.map((node) => {
-    const {
-      parent,
-      incomingEdges,
-      outgoingEdges,
-      children,
-      ...structuredNode
-    } = node;
+  const nodes: CytoscapeNode[] = graph.nodes
+    .filter((node) => node.$graph.nodeClass === "visual")
+    .map((node) => {
+      const {
+        parent,
+        incomingEdges,
+        outgoingEdges,
+        children,
+        ...structuredNode
+      } = node;
 
-    const defaultParent =
-      node.location?.code && node.tenant.tenantId
-        ? `${node.tenant.tenantId}-${node.location?.code}`
-        : node.tenant.tenantId;
-    return {
-      group: "nodes",
-      data: Object.assign(structuredNode, {
-        id: node.$graph.id,
-        parent: node.$graph.parent ?? defaultParent,
-        name: node.$graph.label,
-        type: node.$graph.nodeType,
-      }),
-    };
-  });
+      const defaultParent =
+        node.location?.code && node.tenant.tenantId
+          ? `${node.tenant.tenantId}-${node.location?.code}`
+          : node.tenant.tenantId;
+      return {
+        group: "nodes",
+        data: Object.assign(structuredNode, {
+          id: node.resource.id,
+          parent: node.$graph.parent ?? defaultParent,
+          name: node.resource.name,
+          type: node.$graph.nodeType,
+        }),
+      };
+    });
 
   const edges: CytoscapeEdge[] = graph.edges.map((edge) => ({
     group: "edges",
     data: {
       id: edge.id,
       name: edge.name as string,
-      source: edge.source.$graph.id,
-      target: edge.target.$graph.id,
+      source: edge.source.resource.id,
+      target: edge.target.resource.id,
       metadata: edge.metadata,
     },
   }));

--- a/packages/informational-serializer/LICENSE
+++ b/packages/informational-serializer/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/packages/informational-serializer/package.json
+++ b/packages/informational-serializer/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@infrascan/informational-serializer",
+  "version": "0.1.0",
+  "description": "A trivial graph serializer intended for non-visual consumption, retaining all nodes and no edges.",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rm -rf dist ; tsup --config internal/tsconfig/tsup.json",
+    "prepublish": "rm -rf dist ; tsup --config internal/tsconfig/tsup.json",
+    "test": "echo \"Error: no test specified\"",
+    "lint": "tsc --noEmit ; prettier src/**/*.ts -c ; eslint .",
+    "lint:fix": "prettier src/**/*.ts -w ; eslint . --fix",
+    "clean": "rm -rf dist node_modules"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/infrascan/infrascan.git"
+  },
+  "keywords": [
+    "cytoscape",
+    "infrascan"
+  ],
+  "author": "Liam Farrelly <liam@l3f7.dev> (https://whoisli.am/)",
+  "license": "MPL-2.0",
+  "homepage": "https://github.com/infrascan/infrascan#readme",
+  "bugs": {
+    "url": "https://github.com/infrascan/infrascan/issues"
+  },
+  "devDependencies": {
+    "@infrascan/shared-types": "^0.6.0"
+  }
+}

--- a/packages/informational-serializer/src/index.ts
+++ b/packages/informational-serializer/src/index.ts
@@ -1,0 +1,55 @@
+import type {
+  Graph,
+  Node as GraphNode,
+  Edge as GraphEdge,
+  Readable,
+} from "@infrascan/shared-types";
+
+export type Node = Omit<
+  Readable<GraphNode>,
+  "incomingEdges" | "outgoingEdges" | "children"
+>;
+
+type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+type MaleableNode = WithOptional<
+  Readable<GraphNode>,
+  "incomingEdges" | "outgoingEdges"
+>;
+
+export interface Edge extends Omit<Readable<GraphEdge>, "source" | "target"> {
+  source: string;
+  target: string;
+}
+
+export interface InformationalGraph {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+export function serializeGraph(graph: Graph): InformationalGraph {
+  const nodes = graph.nodes.map((node): Node => {
+    const copy: MaleableNode = structuredClone(node);
+    // remove object references
+    delete copy.incomingEdges;
+    delete copy.outgoingEdges;
+    delete copy.children;
+    delete copy.parent;
+    return copy;
+  });
+
+  const edges = graph.edges.map(
+    (edge): Edge => ({
+      id: edge.id,
+      name: edge.name,
+      source: edge.source.resource.id,
+      target: edge.target.resource.id,
+      metadata: edge.metadata,
+    }),
+  );
+
+  return {
+    nodes,
+    edges,
+  };
+}

--- a/packages/informational-serializer/tsconfig.json
+++ b/packages/informational-serializer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@infrascan/tsconfig/base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "Node16",
+    "baseUrl": "src",
+    "rootDir": "src",
+    "declarationMap": false,
+    "outDir": "./dist"
+  }
+}

--- a/packages/sdk/src/graph.ts
+++ b/packages/sdk/src/graph.ts
@@ -42,6 +42,7 @@ export function buildAccountNode(account: string): BaseState {
     $graph: {
       id: account,
       label: humanReadableAccountName,
+      nodeClass: "visual",
       nodeType: AWS_ACCOUNT_SERVICE_KEY,
     },
     $metadata: {
@@ -68,6 +69,7 @@ export function buildRegionNode(account: string, region: string): BaseState {
       id: `${account}-${region}`,
       label: humanReadableRegionName,
       nodeType: AWS_REGION_SERVICE_KEY,
+      nodeClass: "visual",
       parent: account,
     },
     $metadata: {

--- a/packages/shared-types/src/graph.ts
+++ b/packages/shared-types/src/graph.ts
@@ -56,18 +56,6 @@ export interface Node extends BaseState<unknown> {
   outgoingEdges: ElementRecord<string, Edge, string>;
 }
 
-export interface NodeOld {
-  id: string;
-  name: string;
-  metadata: Record<string, unknown>;
-  service?: string;
-  type?: string;
-  parent?: ElementType<Node, string>;
-  children?: ElementRecord<string, Node, string>;
-  incomingEdges: ElementRecord<string, Edge, string>;
-  outgoingEdges: ElementRecord<string, Edge, string>;
-}
-
 export interface Edge {
   id: string;
   name?: string;

--- a/packages/shared-types/src/scan.ts
+++ b/packages/shared-types/src/scan.ts
@@ -36,21 +36,35 @@ export interface Coordinates {
 }
 
 /**
+ * Indicates how the node should be consumed.
+ *
+ * - Informational nodes are not likely to be useful when rendered, but may include useful insights for infrastructure comprehension. Informational nodes are unlikely to have edges.
+ * - Visual nodes should be considered a superset of informational nodes - they convey information and can be rendered in an obvious way.
+ */
+export type NodeClass = "informational" | "visual";
+
+/**
  * Details about the nodes position in the graph and how it relates to other components
  */
 export interface GraphInfo {
   /**
    * The unique ID of the node in the graph
+   * @deprecated Use Resource.id instead
    */
   id: string;
   /**
    * The human readable name of the node in the graph
+   * @deprecated Use Resource.name instead
    */
   label: string;
   /**
    * The type of the node, used for assigning an icon in the graph
    */
   nodeType: string;
+  /**
+   * Indicates if the node is intended to be rendered or used for infrastructure comprehension.
+   */
+  nodeClass: NodeClass;
   /**
    * The ID of the parent node, optional.
    */
@@ -155,6 +169,57 @@ export interface DNS {
 
 export type PublicIpStatus = "enabled" | "disabled";
 
+export type AddressFamily = "ipv4" | "ipv6";
+
+export interface ReservedAddresses {
+  family: AddressFamily;
+  cidrBlock: string;
+  cidrBlockAssociationSets?: [
+    {
+      associationId: string;
+      cidrBlock: string;
+      state: string;
+      stateMessage: string;
+    },
+  ];
+  firstAddress?: string;
+  lastAddress?: string;
+}
+
+export interface IpRange {
+  family?: AddressFamily;
+  cidrBlock?: string;
+  description?: string;
+}
+
+export interface ReferencedAwsSecurityGroup {
+  description?: string;
+  securityGroupId?: string;
+  securityGroupName?: string;
+  referencedAccountId?: string;
+  referencedVpcId?: string;
+  vpcPeeringStatus?: string;
+  vpcPeeringConnectionId?: string;
+}
+
+export interface PrefixLists {
+  description?: string;
+  prefixListId?: string;
+}
+
+export interface AwsNetworkingRules {
+  referencedSecurityGroups?: ReferencedAwsSecurityGroup[];
+  prefixLists?: PrefixLists[];
+}
+
+export interface NetworkRule {
+  fromPort?: number;
+  toPort?: number;
+  protocol?: string;
+  permittedIpRanges?: IpRange[];
+  awsConfig?: AwsNetworkingRules;
+}
+
 /**
  * The network information for a scanned resource which aims to cover both resources being assigned an address
  * and the networking resource itself (VPC, subnet)
@@ -185,26 +250,12 @@ export interface Network {
   /**
    * The IP ranges reserved for a networking resource (VPC, subnet)
    */
-  reservedAddresses?: [
-    {
-      family: "ipv4" | "ipv6";
-      cidrBlock: string;
-      cidrBlockAssociationSets?: [
-        {
-          associationId: string;
-          cidrBlock: string;
-          state: string;
-          stateMessage: string;
-        },
-      ];
-      firstAddress: string;
-      lastAddress: string;
-    },
-  ];
+  reservedAddresses?: ReservedAddresses[];
   /**
    * The information relating to a specific subnet
    */
   subnet?: {
+    state?: string;
     ipv6Only?: boolean;
     availableAddressCount?: number;
   };
@@ -223,6 +274,7 @@ export interface Network {
     interfaceId?: string;
     macAddress?: string;
   };
+  rules?: NetworkRule[];
 }
 
 /**

--- a/plugins/node-reducer/src/reducer.ts
+++ b/plugins/node-reducer/src/reducer.ts
@@ -98,6 +98,7 @@ export function collapseNodes(
       id: `${parent}-${rule.id}`,
       label: `${parent}-${rule.id}`,
       parent,
+      nodeClass: nodes[0]?.$graph.nodeClass ?? "visual",
       nodeType: nodes[0]?.$graph.nodeType,
     },
     tenant: nodes[0].tenant,


### PR DESCRIPTION
A large volume of state was ignored because there wasn't a reasonable way to visualise it. This prevents non-visual clients from consuming the pulled state. To address this, adding a nodeClass of `visual` and `informational` to distinguish. Non-visual use cases should take advantage of the new informational-serializer