### PR TITLE
fix: await iam roles scanning, correct r53 edge generation

### DIFF
--- a/.changeset/cool-rings-call.md
+++ b/.changeset/cool-rings-call.md
@@ -1,0 +1,6 @@
+---
+"@infrascan/aws-route53-scanner": patch
+"@infrascan/sdk": patch
+---
+
+Bug fix in IAM role and Route53 edge calculations

--- a/aws-scanners/route53/src/edges.ts
+++ b/aws-scanners/route53/src/edges.ts
@@ -116,9 +116,12 @@ export async function resolveCloudfrontEdges(
     ) as DistributionSummary[];
 
   return cloudfrontConnectedDomains
-    .map(({ Name, AliasTarget }) => {
+    .map(({ Name, AliasTarget, ResourceRecords }) => {
       const target = cloudfrontRecords.find(
-        ({ DomainName }) => `${DomainName}.` === AliasTarget?.DNSName,
+        ({ DomainName }) =>
+          DomainName != null &&
+          (`${DomainName}.` === AliasTarget?.DNSName ||
+            ResourceRecords?.find(({ Value }) => Value === DomainName)),
       );
       if (target?.ARN && Name) {
         return formatEdge(Name, { name: Name, target: target.ARN });

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,8 +106,8 @@
       "name": "@infrascan/render",
       "version": "0.0.0",
       "devDependencies": {
-        "@infrascan/cytoscape-serializer": "^0.3.3",
-        "@infrascan/shared-types": "^0.6.2",
+        "@infrascan/cytoscape-serializer": "^0.3.4",
+        "@infrascan/shared-types": "^0.7.0",
         "@types/cytoscape": "^3.19.16",
         "typescript": "^5.4.5",
         "vite": "^7.0.0"
@@ -566,7 +566,7 @@
     },
     "aws-scanners/api-gateway": {
       "name": "@infrascan/aws-api-gateway-scanner",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-apigatewayv2": "3.624.0",
@@ -578,7 +578,7 @@
         "@aws-sdk/types": "3.609.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -600,7 +600,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -611,7 +611,7 @@
     },
     "aws-scanners/cloudfront": {
       "name": "@infrascan/aws-cloudfront-scanner",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudfront": "3.624.0",
@@ -624,7 +624,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -635,7 +635,7 @@
     },
     "aws-scanners/cloudwatch-logs": {
       "name": "@infrascan/aws-cloudwatch-logs-scanner",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.624.0",
@@ -646,7 +646,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -663,7 +663,7 @@
         "ejs": "^3.1.9"
       },
       "devDependencies": {
-        "@infrascan/shared-types": "^0.6.2",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/ejs": "^3.1.5",
         "@types/node": "^20.3.1",
@@ -672,7 +672,7 @@
     },
     "aws-scanners/dynamodb": {
       "name": "@infrascan/aws-dynamodb-scanner",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.624.0",
@@ -683,7 +683,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -694,7 +694,7 @@
     },
     "aws-scanners/ec2": {
       "name": "@infrascan/aws-ec2-scanner",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "3.624.0",
@@ -705,7 +705,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.1",
@@ -715,7 +715,7 @@
     },
     "aws-scanners/ecs": {
       "name": "@infrascan/aws-ecs-scanner",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ecs": "3.624.0",
@@ -726,7 +726,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.1",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -737,7 +737,7 @@
     },
     "aws-scanners/elastic-load-balancing": {
       "name": "@infrascan/aws-elastic-load-balancing-scanner",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-elastic-load-balancing-v2": "3.624.0",
@@ -749,7 +749,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -760,7 +760,7 @@
     },
     "aws-scanners/kinesis": {
       "name": "@infrascan/aws-kinesis-scanner",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-kinesis": "3.624.0",
@@ -771,7 +771,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -782,7 +782,7 @@
     },
     "aws-scanners/lambda": {
       "name": "@infrascan/aws-lambda-scanner",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-lambda": "3.624.0",
@@ -793,7 +793,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -804,7 +804,7 @@
     },
     "aws-scanners/rds": {
       "name": "@infrascan/aws-rds-scanner",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-rds": "3.624.0",
@@ -815,7 +815,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -826,7 +826,7 @@
     },
     "aws-scanners/route53": {
       "name": "@infrascan/aws-route53-scanner",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-route-53": "3.624.0",
@@ -842,7 +842,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -853,7 +853,7 @@
     },
     "aws-scanners/s3": {
       "name": "@infrascan/aws-s3-scanner",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "3.624.0",
@@ -864,7 +864,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@smithy/types": "^2.4.0",
         "@types/debug": "^4",
@@ -875,7 +875,7 @@
     },
     "aws-scanners/sns": {
       "name": "@infrascan/aws-sns-scanner",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-sns": "3.624.0",
@@ -886,7 +886,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -897,7 +897,7 @@
     },
     "aws-scanners/sqs": {
       "name": "@infrascan/aws-sqs-scanner",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-sqs": "3.624.0",
@@ -908,7 +908,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -919,7 +919,7 @@
     },
     "aws-scanners/step-function": {
       "name": "@infrascan/aws-step-function-scanner",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-sfn": "3.624.0",
@@ -930,7 +930,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -20015,42 +20015,42 @@
     },
     "packages/aws": {
       "name": "@infrascan/aws",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MPL-2.0",
       "dependencies": {
-        "@infrascan/aws-api-gateway-scanner": "^0.4.2",
+        "@infrascan/aws-api-gateway-scanner": "^0.5.0",
         "@infrascan/aws-autoscaling-scanner": "^0.3.1",
-        "@infrascan/aws-cloudfront-scanner": "^0.4.2",
-        "@infrascan/aws-cloudwatch-logs-scanner": "^0.4.2",
-        "@infrascan/aws-dynamodb-scanner": "^0.4.2",
-        "@infrascan/aws-ec2-scanner": "^0.4.1",
-        "@infrascan/aws-ecs-scanner": "^0.5.2",
-        "@infrascan/aws-elastic-load-balancing-scanner": "^0.4.2",
-        "@infrascan/aws-kinesis-scanner": "^0.3.3",
-        "@infrascan/aws-lambda-scanner": "^0.4.2",
-        "@infrascan/aws-rds-scanner": "^0.4.2",
-        "@infrascan/aws-route53-scanner": "^0.5.0",
-        "@infrascan/aws-s3-scanner": "^0.4.2",
-        "@infrascan/aws-sns-scanner": "^0.4.2",
-        "@infrascan/aws-sqs-scanner": "^0.4.3",
-        "@infrascan/aws-step-function-scanner": "^0.3.3"
+        "@infrascan/aws-cloudfront-scanner": "^0.5.0",
+        "@infrascan/aws-cloudwatch-logs-scanner": "^0.5.0",
+        "@infrascan/aws-dynamodb-scanner": "^0.5.0",
+        "@infrascan/aws-ec2-scanner": "^0.5.0",
+        "@infrascan/aws-ecs-scanner": "^0.6.0",
+        "@infrascan/aws-elastic-load-balancing-scanner": "^0.5.0",
+        "@infrascan/aws-kinesis-scanner": "^0.4.0",
+        "@infrascan/aws-lambda-scanner": "^0.5.0",
+        "@infrascan/aws-rds-scanner": "^0.5.0",
+        "@infrascan/aws-route53-scanner": "^0.6.0",
+        "@infrascan/aws-s3-scanner": "^0.5.0",
+        "@infrascan/aws-sns-scanner": "^0.5.0",
+        "@infrascan/aws-sqs-scanner": "^0.5.0",
+        "@infrascan/aws-step-function-scanner": "^0.4.0"
       },
       "devDependencies": {
-        "@infrascan/sdk": "^0.5.0",
+        "@infrascan/sdk": "^0.6.0",
         "@infrascan/tsconfig": "*"
       }
     },
     "packages/cli": {
       "name": "@infrascan/cli",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "3.624.0",
-        "@infrascan/aws": "^0.5.0",
-        "@infrascan/cytoscape-serializer": "^0.3.0",
+        "@infrascan/aws": "^0.5.4",
+        "@infrascan/cytoscape-serializer": "^0.3.4",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/informational-serializer": "^0.1.0",
-        "@infrascan/sdk": "^0.5.0",
+        "@infrascan/informational-serializer": "^0.2.0",
+        "@infrascan/sdk": "^0.6.0",
         "@rushstack/ts-command-line": "^4.15.2",
         "@smithy/shared-ini-file-loader": "^2.2.2",
         "ejs": "^3.1.9",
@@ -20062,7 +20062,7 @@
       },
       "devDependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@smithy/types": "^2.4.0",
         "@types/ejs": "^3.1.5",
         "ts-node": "^10.9.1",
@@ -20091,7 +20091,7 @@
         "jmespath": "^0.16.0"
       },
       "devDependencies": {
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "eslint-config-custom": "*",
         "ts-node": "^10.9.1",
         "tsconfig": "*",
@@ -20100,10 +20100,10 @@
     },
     "packages/cytoscape-serializer": {
       "name": "@infrascan/cytoscape-serializer",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MPL-2.0",
       "devDependencies": {
-        "@infrascan/shared-types": "^0.6.0"
+        "@infrascan/shared-types": "^0.7.0"
       }
     },
     "packages/fs-connector": {
@@ -20114,7 +20114,7 @@
         "minimatch": "^9.0.3"
       },
       "devDependencies": {
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "eslint-config-custom": "*",
         "tsconfig": "*",
         "typescript": "^5.4.5"
@@ -20122,10 +20122,10 @@
     },
     "packages/informational-serializer": {
       "name": "@infrascan/informational-serializer",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MPL-2.0",
       "devDependencies": {
-        "@infrascan/shared-types": "^0.6.0"
+        "@infrascan/shared-types": "^0.7.0"
       }
     },
     "packages/s3-connector": {
@@ -20138,7 +20138,7 @@
       },
       "devDependencies": {
         "@aws-sdk/util-stream-node": "^3.374.0",
-        "@infrascan/shared-types": "^0.6.2",
+        "@infrascan/shared-types": "^0.7.0",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-custom": "*",
         "tap": "^21",
@@ -20148,7 +20148,7 @@
     },
     "packages/sdk": {
       "name": "@infrascan/sdk",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "3.624.0",
@@ -20185,7 +20185,7 @@
     },
     "packages/shared-types": {
       "name": "@infrascan/shared-types",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@aws-sdk/types": "3.609.0",
@@ -20196,14 +20196,14 @@
     },
     "plugins/node-reducer": {
       "name": "@infrascan/node-reducer-plugin",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@infrascan/core": "*",
         "minimatch": "^9.0.4"
       },
       "devDependencies": {
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@types/node": "^20.12.10",
         "tap": "^21",
         "tsconfig": "*"
@@ -24386,23 +24386,23 @@
     "@infrascan/aws": {
       "version": "file:packages/aws",
       "requires": {
-        "@infrascan/aws-api-gateway-scanner": "^0.4.2",
+        "@infrascan/aws-api-gateway-scanner": "^0.5.0",
         "@infrascan/aws-autoscaling-scanner": "^0.3.1",
-        "@infrascan/aws-cloudfront-scanner": "^0.4.2",
-        "@infrascan/aws-cloudwatch-logs-scanner": "^0.4.2",
-        "@infrascan/aws-dynamodb-scanner": "^0.4.2",
-        "@infrascan/aws-ec2-scanner": "^0.4.1",
-        "@infrascan/aws-ecs-scanner": "^0.5.2",
-        "@infrascan/aws-elastic-load-balancing-scanner": "^0.4.2",
-        "@infrascan/aws-kinesis-scanner": "^0.3.3",
-        "@infrascan/aws-lambda-scanner": "^0.4.2",
-        "@infrascan/aws-rds-scanner": "^0.4.2",
-        "@infrascan/aws-route53-scanner": "^0.5.0",
-        "@infrascan/aws-s3-scanner": "^0.4.2",
-        "@infrascan/aws-sns-scanner": "^0.4.2",
-        "@infrascan/aws-sqs-scanner": "^0.4.3",
-        "@infrascan/aws-step-function-scanner": "^0.3.3",
-        "@infrascan/sdk": "^0.5.0",
+        "@infrascan/aws-cloudfront-scanner": "^0.5.0",
+        "@infrascan/aws-cloudwatch-logs-scanner": "^0.5.0",
+        "@infrascan/aws-dynamodb-scanner": "^0.5.0",
+        "@infrascan/aws-ec2-scanner": "^0.5.0",
+        "@infrascan/aws-ecs-scanner": "^0.6.0",
+        "@infrascan/aws-elastic-load-balancing-scanner": "^0.5.0",
+        "@infrascan/aws-kinesis-scanner": "^0.4.0",
+        "@infrascan/aws-lambda-scanner": "^0.5.0",
+        "@infrascan/aws-rds-scanner": "^0.5.0",
+        "@infrascan/aws-route53-scanner": "^0.6.0",
+        "@infrascan/aws-s3-scanner": "^0.5.0",
+        "@infrascan/aws-sns-scanner": "^0.5.0",
+        "@infrascan/aws-sqs-scanner": "^0.5.0",
+        "@infrascan/aws-step-function-scanner": "^0.4.0",
+        "@infrascan/sdk": "^0.6.0",
         "@infrascan/tsconfig": "*"
       }
     },
@@ -24415,7 +24415,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24433,7 +24433,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24452,7 +24452,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24471,7 +24471,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24484,7 +24484,7 @@
     "@infrascan/aws-codegen": {
       "version": "file:aws-scanners/codegen",
       "requires": {
-        "@infrascan/shared-types": "^0.6.2",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/ejs": "^3.1.5",
         "@types/node": "^20.3.1",
@@ -24500,7 +24500,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24518,7 +24518,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.1",
@@ -24535,7 +24535,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.1",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24554,7 +24554,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24572,7 +24572,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24590,7 +24590,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24608,7 +24608,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24630,7 +24630,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24649,7 +24649,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@smithy/types": "^2.4.0",
         "@types/debug": "^4",
@@ -24667,7 +24667,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24685,7 +24685,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24703,7 +24703,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -24718,12 +24718,12 @@
       "requires": {
         "@aws-sdk/credential-providers": "3.624.0",
         "@aws-sdk/types": "3.609.0",
-        "@infrascan/aws": "^0.5.0",
-        "@infrascan/cytoscape-serializer": "^0.3.0",
+        "@infrascan/aws": "^0.5.4",
+        "@infrascan/cytoscape-serializer": "^0.3.4",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/informational-serializer": "^0.1.0",
-        "@infrascan/sdk": "^0.5.0",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/informational-serializer": "^0.2.0",
+        "@infrascan/sdk": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@rushstack/ts-command-line": "^4.15.2",
         "@smithy/shared-ini-file-loader": "^2.2.2",
         "@smithy/types": "^2.4.0",
@@ -24748,7 +24748,7 @@
     "@infrascan/core": {
       "version": "file:packages/core",
       "requires": {
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "eslint-config-custom": "*",
         "jmespath": "^0.16.0",
         "ts-node": "^10.9.1",
@@ -24759,13 +24759,13 @@
     "@infrascan/cytoscape-serializer": {
       "version": "file:packages/cytoscape-serializer",
       "requires": {
-        "@infrascan/shared-types": "^0.6.0"
+        "@infrascan/shared-types": "^0.7.0"
       }
     },
     "@infrascan/fs-connector": {
       "version": "file:packages/fs-connector",
       "requires": {
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "eslint-config-custom": "*",
         "minimatch": "^9.0.3",
         "tsconfig": "*",
@@ -24775,14 +24775,14 @@
     "@infrascan/informational-serializer": {
       "version": "file:packages/informational-serializer",
       "requires": {
-        "@infrascan/shared-types": "^0.6.0"
+        "@infrascan/shared-types": "^0.7.0"
       }
     },
     "@infrascan/node-reducer-plugin": {
       "version": "file:plugins/node-reducer",
       "requires": {
         "@infrascan/core": "*",
-        "@infrascan/shared-types": "^0.6.0",
+        "@infrascan/shared-types": "^0.7.0",
         "@types/node": "^20.12.10",
         "minimatch": "^9.0.4",
         "tap": "^21",
@@ -24792,8 +24792,8 @@
     "@infrascan/render": {
       "version": "file:apps/render",
       "requires": {
-        "@infrascan/cytoscape-serializer": "^0.3.3",
-        "@infrascan/shared-types": "^0.6.2",
+        "@infrascan/cytoscape-serializer": "^0.3.4",
+        "@infrascan/shared-types": "^0.7.0",
         "@types/cytoscape": "^3.19.16",
         "typescript": "^5.4.5",
         "vite": "^7.0.0"
@@ -25029,7 +25029,7 @@
       "requires": {
         "@aws-sdk/client-s3": "3.624.0",
         "@aws-sdk/util-stream-node": "^3.374.0",
-        "@infrascan/shared-types": "^0.6.2",
+        "@infrascan/shared-types": "^0.7.0",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-custom": "*",
         "minimatch": "^9.0.3",

--- a/packages/sdk/src/scan.ts
+++ b/packages/sdk/src/scan.ts
@@ -109,7 +109,7 @@ export async function scanService(
   if (serviceScanner.getIamRoles != null) {
     const iamRoles = await serviceScanner.getIamRoles(connector);
     for (const { roleArn } of iamRoles) {
-      scanIamRole(iamStorage, iamClient, roleArn).catch((err) => {
+      await scanIamRole(iamStorage, iamClient, roleArn).catch((err) => {
         console.error("An error occurred while scanning role:", roleArn);
         if (err instanceof Error) {
           console.error(err.message);


### PR DESCRIPTION
Route53 isn't correctly resolving edges when DNS records are not aliases. Update matching logic to handle e.g. CNAME records.

Await iam role scans in sdk to remove race condition.