### PR TITLE
Remove version mismatch for aws sdk internal types

### DIFF
--- a/.changeset/beige-toys-shake.md
+++ b/.changeset/beige-toys-shake.md
@@ -1,0 +1,6 @@
+---
+"@infrascan/cli": patch
+"@infrascan/sdk": patch
+---
+
+Update aws utility dependencies

--- a/aws-scanners/s3/package.json
+++ b/aws-scanners/s3/package.json
@@ -46,7 +46,6 @@
     "@infrascan/fs-connector": "^0.3.0",
     "@infrascan/shared-types": "^0.7.0",
     "@infrascan/tsconfig": "*",
-    "@smithy/types": "^2.4.0",
     "aws-sdk-client-mock": "^3.0.0",
     "eslint-config-codegen": "^1.0.0",
     "tap": "^21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -826,7 +826,7 @@
     },
     "aws-scanners/route53": {
       "name": "@infrascan/aws-route53-scanner",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-route-53": "3.624.0",
@@ -866,7 +866,6 @@
         "@infrascan/fs-connector": "^0.3.0",
         "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
-        "@smithy/types": "^2.4.0",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-codegen": "^1.0.0",
@@ -1144,47 +1143,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-apigatewayv2/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1266,47 +1230,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-auto-scaling/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-auto-scaling/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-auto-scaling/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-auto-scaling/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1390,47 +1319,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cloudfront/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cloudfront/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cloudfront/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1515,47 +1409,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1648,47 +1507,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1772,47 +1596,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1908,47 +1697,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2043,47 +1797,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ecs/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2177,47 +1896,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-elastic-load-balancing-v2/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elastic-load-balancing-v2/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-elastic-load-balancing-v2/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-elastic-load-balancing-v2/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2299,47 +1983,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-iam/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2424,47 +2073,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-kinesis/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2550,47 +2164,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2673,47 +2252,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-rds/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2797,47 +2341,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-route-53/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-route-53/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2935,47 +2444,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3057,47 +2531,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sfn/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sfn/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sfn/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sfn/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3190,47 +2629,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sns/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sns/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sns/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sns/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3313,47 +2717,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sqs/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sqs/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3483,47 +2852,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3553,47 +2887,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3673,47 +2972,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
       "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
       "dependencies": {
         "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3780,17 +3044,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/core/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/core/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -3851,17 +3104,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.620.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
@@ -3870,17 +3112,6 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3900,17 +3131,6 @@
         "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/util-stream": "^3.1.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3941,29 +3161,6 @@
         "@aws-sdk/client-sts": "^3.624.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.624.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.624.0.tgz",
@@ -3986,29 +3183,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.620.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
@@ -4018,29 +3192,6 @@
         "@smithy/property-provider": "^3.1.3",
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4064,29 +3215,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.621.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
@@ -4102,17 +3230,6 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-sts": "^3.621.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
@@ -4135,17 +3252,6 @@
         "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4181,17 +3287,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
       "version": "3.620.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.620.0.tgz",
@@ -4208,17 +3303,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-expect-continue": {
       "version": "3.620.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.620.0.tgz",
@@ -4227,17 +3311,6 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4286,17 +3359,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -4335,17 +3397,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-location-constraint": {
       "version": "3.609.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.609.0.tgz",
@@ -4353,17 +3404,6 @@
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4383,17 +3423,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-logger/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.620.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
@@ -4402,17 +3431,6 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4460,17 +3478,6 @@
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-uri-escape": "^3.0.0",
         "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4547,17 +3554,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -4589,17 +3585,6 @@
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-route53/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4659,17 +3644,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -4721,17 +3695,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -4769,17 +3732,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-ssec/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.620.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.620.0.tgz",
@@ -4789,17 +3741,6 @@
         "@aws-sdk/util-endpoints": "3.614.0",
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4816,17 +3757,6 @@
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4878,17 +3808,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -4931,46 +3850,12 @@
         "@aws-sdk/client-sso-oidc": "^3.614.0"
       }
     },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/types": {
       "version": "3.609.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
       "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
       "dependencies": {
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/types/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5002,17 +3887,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-format-url": {
       "version": "3.609.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.609.0.tgz",
@@ -5021,17 +3895,6 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5049,20 +3912,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-stream-node": {
-      "version": "3.374.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.374.0.tgz",
-      "integrity": "sha512-E9niTpJC9vYQAlManm8cpXGxMmSOBwGQj0TwLGECIaA51Bk+7RjlXAZkcu85PvIps90N3ollYtWWSsRBnH2SJw==",
-      "deprecated": "This package has moved to @smithy/util-stream",
-      "dev": true,
-      "dependencies": {
-        "@smithy/util-stream-node": "^1.0.2",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.609.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
@@ -5072,17 +3921,6 @@
         "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
@@ -5107,34 +3945,12 @@
         }
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@aws-sdk/xml-builder": {
       "version": "3.609.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.609.0.tgz",
       "integrity": "sha512-l9XxNcA4HX98rwCC2/KoiWcmEiRfZe4G+mYwDbCFT87JIMj6GBhLDkAzr/W8KAaA2IDr8Vc6J8fZPgVulxxfMA==",
       "dependencies": {
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7375,22 +6191,12 @@
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
-      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7429,17 +6235,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/config-resolver/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/core": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.3.2.tgz",
@@ -7452,17 +6247,6 @@
         "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/core/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7484,17 +6268,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/eventstream-serde-browser": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.6.tgz",
@@ -7502,17 +6275,6 @@
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^3.0.5",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-browser/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7531,17 +6293,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/eventstream-serde-config-resolver/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/eventstream-serde-node": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.5.tgz",
@@ -7549,17 +6300,6 @@
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^3.0.5",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-node/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7603,17 +6343,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@smithy/eventstream-serde-universal/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/fetch-http-handler": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
@@ -7626,17 +6355,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/hash-blob-browser": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-3.1.2.tgz",
@@ -7646,17 +6364,6 @@
         "@smithy/chunked-blob-reader-native": "^3.0.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@smithy/hash-blob-browser/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/hash-node": {
@@ -7677,17 +6384,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
       "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -7743,17 +6439,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/hash-stream-node/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/hash-stream-node/node_modules/@smithy/util-buffer-from": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -7787,17 +6472,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@smithy/invalid-dependency/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/is-array-buffer": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
@@ -7823,17 +6497,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
       "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/md5-js/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -7878,17 +6541,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/middleware-content-length/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/middleware-endpoint": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
@@ -7900,29 +6552,6 @@
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7943,41 +6572,6 @@
         "@smithy/util-retry": "^3.0.3",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -8007,34 +6601,12 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/middleware-serde/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/middleware-stack": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
       "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
       "dependencies": {
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8055,49 +6627,16 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/node-config-provider/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-      "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
-      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.3.tgz",
+      "integrity": "sha512-BrpZOaZ4RCbcJ2igiSNG16S+kgAc65l/2hmxWdmhyoGWHTLlzQzr06PXavJp9OBlPEG/sHlqdxjWmjzV66+BSQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8116,34 +6655,13 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/property-provider/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
-      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+      "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8151,23 +6669,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
-      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-uri-escape": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8186,38 +6694,29 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+    "node_modules/@smithy/service-error-classification": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+      "integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
+        "@smithy/types": "^3.7.2"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/service-error-classification": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
-      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
-      "dependencies": {
-        "@smithy/types": "^2.9.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
-      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+      "integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/smithy-client": {
@@ -8236,26 +6735,16 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/smithy-client/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+    "node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/types": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
-      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/url-parser": {
@@ -8266,17 +6755,6 @@
         "@smithy/querystring-parser": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@smithy/url-parser/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/@smithy/util-base64": {
@@ -8384,17 +6862,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@smithy/util-defaults-mode-browser/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/util-defaults-mode-node": {
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.14.tgz",
@@ -8412,17 +6879,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@smithy/util-defaults-mode-node/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@smithy/util-endpoints": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.5.tgz",
@@ -8430,17 +6886,6 @@
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8470,38 +6915,29 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+    "node_modules/@smithy/util-retry": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+      "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
+      "license": "Apache-2.0",
       "dependencies": {
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/util-retry": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
-      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
-      "dependencies": {
-        "@smithy/service-error-classification": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
     "node_modules/@smithy/util-stream": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
-      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.4.tgz",
+      "integrity": "sha512-SGhGBG/KupieJvJSZp/rfHHka8BFgj56eek9px4pp7lZbOF+fRiVr4U7A3y3zJD8uGhxq32C5D96HxsTC9BckQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/fetch-http-handler": "^4.1.3",
+        "@smithy/node-http-handler": "^3.3.3",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
@@ -8512,141 +6948,23 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@smithy/util-stream-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream-node/-/util-stream-node-1.1.0.tgz",
-      "integrity": "sha512-gC7La6Xh/Q6ruY2tF2kSmVYxZpca9nKMYsbPSNDUv6EKW6kMHO3UqxTQ4kixynUOz2uZ3igvuX+1d2w+LaD2dw==",
-      "dev": true,
+    "node_modules/@smithy/util-stream/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.3.tgz",
+      "integrity": "sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-http-handler": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-buffer-from": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream-node/node_modules/@smithy/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^1.2.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream-node/node_modules/@smithy/is-array-buffer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.1.0.tgz",
-      "integrity": "sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream-node/node_modules/@smithy/node-http-handler": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
-      "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/abort-controller": "^1.1.0",
-        "@smithy/protocol-http": "^1.2.0",
-        "@smithy/querystring-builder": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream-node/node_modules/@smithy/protocol-http": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
-      "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^1.2.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream-node/node_modules/@smithy/querystring-builder": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
-      "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-uri-escape": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream-node/node_modules/@smithy/types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
-      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream-node/node_modules/@smithy/util-buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.1.0.tgz",
-      "integrity": "sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==",
-      "dev": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream-node/node_modules/@smithy/util-uri-escape": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
-      "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/is-array-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
       "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8708,17 +7026,6 @@
       "dependencies": {
         "@smithy/abort-controller": "^3.1.1",
         "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@smithy/util-waiter/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -20052,7 +18359,7 @@
         "@infrascan/informational-serializer": "^0.2.0",
         "@infrascan/sdk": "^0.6.0",
         "@rushstack/ts-command-line": "^4.15.2",
-        "@smithy/shared-ini-file-loader": "^2.2.2",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
         "ejs": "^3.1.9",
         "minimatch": "^6.1.6",
         "open": "^10.1.0"
@@ -20063,7 +18370,7 @@
       "devDependencies": {
         "@aws-sdk/types": "3.609.0",
         "@infrascan/shared-types": "^0.7.0",
-        "@smithy/types": "^2.4.0",
+        "@smithy/types": "^3.3.0",
         "@types/ejs": "^3.1.5",
         "ts-node": "^10.9.1",
         "typescript": "^5.4.5"
@@ -20137,8 +18444,8 @@
         "minimatch": "^9.0.3"
       },
       "devDependencies": {
-        "@aws-sdk/util-stream-node": "^3.374.0",
         "@infrascan/shared-types": "^0.7.0",
+        "@smithy/util-stream": "^3.3.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-custom": "*",
         "tap": "^21",
@@ -20148,14 +18455,14 @@
     },
     "packages/sdk": {
       "name": "@infrascan/sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "3.624.0",
         "@aws-sdk/client-iam": "3.624.0",
         "@aws-sdk/client-sts": "3.624.0",
         "@infrascan/core": "^0.5.0",
-        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-retry": "^3.0.1",
         "debug": "^4",
         "jmespath": "^0.16.0",
         "minimatch": "^5.1.0"
@@ -20362,38 +18669,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -20465,38 +18746,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -20570,38 +18825,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -20676,38 +18905,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -20783,38 +18986,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -20888,38 +19065,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -20998,38 +19149,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -21107,38 +19232,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -21215,38 +19314,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -21318,38 +19391,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -21424,38 +19471,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -21531,38 +19552,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -21635,38 +19630,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -21740,38 +19709,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -21859,38 +19802,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -21962,38 +19879,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -22069,38 +19960,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -22173,38 +20038,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -22272,38 +20111,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -22372,38 +20185,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -22473,38 +20260,12 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
           "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
           "requires": {
             "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
@@ -22558,14 +20319,6 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -22604,16 +20357,6 @@
         "@smithy/property-provider": "^3.1.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/credential-provider-env": {
@@ -22625,16 +20368,6 @@
         "@smithy/property-provider": "^3.1.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/credential-provider-http": {
@@ -22651,16 +20384,6 @@
         "@smithy/types": "^3.3.0",
         "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/credential-provider-ini": {
@@ -22679,25 +20402,6 @@
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/shared-ini-file-loader": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/credential-provider-node": {
@@ -22717,25 +20421,6 @@
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/shared-ini-file-loader": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/credential-provider-process": {
@@ -22748,25 +20433,6 @@
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/shared-ini-file-loader": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/credential-provider-sso": {
@@ -22781,25 +20447,6 @@
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/shared-ini-file-loader": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
@@ -22811,16 +20458,6 @@
         "@smithy/property-provider": "^3.1.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/credential-providers": {
@@ -22844,16 +20481,6 @@
         "@smithy/property-provider": "^3.1.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/endpoint-cache": {
@@ -22877,16 +20504,6 @@
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
@@ -22900,16 +20517,6 @@
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-expect-continue": {
@@ -22921,16 +20528,6 @@
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
@@ -22966,14 +20563,6 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -23003,16 +20592,6 @@
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-location-constraint": {
@@ -23023,16 +20602,6 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-logger": {
@@ -23043,16 +20612,6 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
@@ -23064,16 +20623,6 @@
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-sdk-ec2": {
@@ -23111,14 +20660,6 @@
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-uri-escape": "^3.0.0",
             "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
             "tslib": "^2.6.2"
           }
         },
@@ -23179,14 +20720,6 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -23215,16 +20748,6 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
@@ -23271,14 +20794,6 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -23320,14 +20835,6 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -23356,16 +20863,6 @@
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/middleware-user-agent": {
@@ -23378,16 +20875,6 @@
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/region-config-resolver": {
@@ -23401,16 +20888,6 @@
         "@smithy/util-config-provider": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
@@ -23449,14 +20926,6 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -23487,25 +20956,6 @@
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/shared-ini-file-loader": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/types": {
@@ -23515,16 +20965,6 @@
       "requires": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/util-arn-parser": {
@@ -23544,16 +20984,6 @@
         "@smithy/types": "^3.3.0",
         "@smithy/util-endpoints": "^2.0.5",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/util-format-url": {
@@ -23565,16 +20995,6 @@
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/util-locate-window": {
@@ -23582,16 +21002,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
       "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/util-stream-node": {
-      "version": "3.374.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.374.0.tgz",
-      "integrity": "sha512-E9niTpJC9vYQAlManm8cpXGxMmSOBwGQj0TwLGECIaA51Bk+7RjlXAZkcu85PvIps90N3ollYtWWSsRBnH2SJw==",
-      "dev": true,
-      "requires": {
-        "@smithy/util-stream-node": "^1.0.2",
         "tslib": "^2.5.0"
       }
     },
@@ -23604,16 +21014,6 @@
         "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/util-user-agent-node": {
@@ -23625,16 +21025,6 @@
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@aws-sdk/xml-builder": {
@@ -23644,16 +21034,6 @@
       "requires": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@babel/runtime": {
@@ -24651,7 +22031,6 @@
         "@infrascan/fs-connector": "^0.3.0",
         "@infrascan/shared-types": "^0.7.0",
         "@infrascan/tsconfig": "*",
-        "@smithy/types": "^2.4.0",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
         "debug": "^4",
@@ -24725,8 +22104,8 @@
         "@infrascan/sdk": "^0.6.0",
         "@infrascan/shared-types": "^0.7.0",
         "@rushstack/ts-command-line": "^4.15.2",
-        "@smithy/shared-ini-file-loader": "^2.2.2",
-        "@smithy/types": "^2.4.0",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.3.0",
         "@types/ejs": "^3.1.5",
         "ejs": "^3.1.9",
         "minimatch": "^6.1.6",
@@ -25028,8 +22407,8 @@
       "version": "file:packages/s3-connector",
       "requires": {
         "@aws-sdk/client-s3": "3.624.0",
-        "@aws-sdk/util-stream-node": "^3.374.0",
         "@infrascan/shared-types": "^0.7.0",
+        "@smithy/util-stream": "^3.3.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-custom": "*",
         "minimatch": "^9.0.3",
@@ -25047,7 +22426,7 @@
         "@aws-sdk/types": "3.609.0",
         "@infrascan/core": "^0.5.0",
         "@infrascan/shared-types": "*",
-        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-retry": "^3.0.1",
         "@types/debug": "^4",
         "@types/jmespath": "^0.15.0",
         "@types/minimatch": "^5.1.2",
@@ -25798,22 +23177,12 @@
       "dev": true
     },
     "@smithy/abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
-      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
       "requires": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/chunked-blob-reader": {
@@ -25843,16 +23212,6 @@
         "@smithy/util-config-provider": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/core": {
@@ -25868,16 +23227,6 @@
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/credential-provider-imds": {
@@ -25890,16 +23239,6 @@
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/eventstream-serde-browser": {
@@ -25910,16 +23249,6 @@
         "@smithy/eventstream-serde-universal": "^3.0.5",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/eventstream-serde-config-resolver": {
@@ -25929,16 +23258,6 @@
       "requires": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/eventstream-serde-node": {
@@ -25949,16 +23268,6 @@
         "@smithy/eventstream-serde-universal": "^3.0.5",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/eventstream-serde-universal": {
@@ -25991,14 +23300,6 @@
             "@smithy/util-hex-encoding": "^3.0.0",
             "tslib": "^2.6.2"
           }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
         }
       }
     },
@@ -26012,16 +23313,6 @@
         "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/hash-blob-browser": {
@@ -26033,16 +23324,6 @@
         "@smithy/chunked-blob-reader-native": "^3.0.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/hash-node": {
@@ -26060,14 +23341,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
           "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -26110,14 +23383,6 @@
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
         "@smithy/util-buffer-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
@@ -26145,16 +23410,6 @@
       "requires": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/is-array-buffer": {
@@ -26179,14 +23434,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
           "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -26219,16 +23466,6 @@
         "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/middleware-endpoint": {
@@ -26243,25 +23480,6 @@
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/shared-ini-file-loader": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/middleware-retry": {
@@ -26280,32 +23498,6 @@
         "uuid": "^9.0.1"
       },
       "dependencies": {
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
         "uuid": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -26320,16 +23512,6 @@
       "requires": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/middleware-stack": {
@@ -26339,16 +23521,6 @@
       "requires": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/node-config-provider": {
@@ -26360,47 +23532,18 @@
         "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/shared-ini-file-loader": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.4.tgz",
-          "integrity": "sha512-qMxS4hBGB8FY2GQqshcRUy1K6k8aBWP5vwm8qKkCT3A9K2dawUwOIJfqh9Yste/Bl0J2lzosVyrXDj68kLcHXQ==",
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/node-http-handler": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
-      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.3.tgz",
+      "integrity": "sha512-BrpZOaZ4RCbcJ2igiSNG16S+kgAc65l/2hmxWdmhyoGWHTLlzQzr06PXavJp9OBlPEG/sHlqdxjWmjzV66+BSQ==",
       "requires": {
-        "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.1.0",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/types": "^3.3.0",
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/property-provider": {
@@ -26410,55 +23553,25 @@
       "requires": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/protocol-http": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
-      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+      "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
       "requires": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.2",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/querystring-builder": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
-      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
       "requires": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-uri-escape": "^3.0.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/querystring-parser": {
@@ -26468,33 +23581,23 @@
       "requires": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/service-error-classification": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
-      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+      "integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
       "requires": {
-        "@smithy/types": "^2.9.1"
+        "@smithy/types": "^3.7.2"
       }
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
-      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+      "integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
       "requires": {
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/smithy-client": {
@@ -26508,24 +23611,14 @@
         "@smithy/types": "^3.3.0",
         "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/types": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
-      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
       "requires": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/url-parser": {
@@ -26536,16 +23629,6 @@
         "@smithy/querystring-parser": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/util-base64": {
@@ -26629,16 +23712,6 @@
         "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/util-defaults-mode-node": {
@@ -26653,16 +23726,6 @@
         "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/util-endpoints": {
@@ -26673,16 +23736,6 @@
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/util-hex-encoding": {
@@ -26700,36 +23753,26 @@
       "requires": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@smithy/util-retry": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
-      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+      "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
       "requires": {
-        "@smithy/service-error-classification": "^2.1.1",
-        "@smithy/types": "^2.9.1",
-        "tslib": "^2.5.0"
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       }
     },
     "@smithy/util-stream": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
-      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.4.tgz",
+      "integrity": "sha512-SGhGBG/KupieJvJSZp/rfHHka8BFgj56eek9px4pp7lZbOF+fRiVr4U7A3y3zJD8uGhxq32C5D96HxsTC9BckQ==",
       "requires": {
-        "@smithy/fetch-http-handler": "^3.2.4",
-        "@smithy/node-http-handler": "^3.1.4",
-        "@smithy/types": "^3.3.0",
+        "@smithy/fetch-http-handler": "^4.1.3",
+        "@smithy/node-http-handler": "^3.3.3",
+        "@smithy/types": "^3.7.2",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
         "@smithy/util-hex-encoding": "^3.0.0",
@@ -26737,18 +23780,22 @@
         "tslib": "^2.6.2"
       },
       "dependencies": {
+        "@smithy/fetch-http-handler": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.3.tgz",
+          "integrity": "sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA==",
+          "requires": {
+            "@smithy/protocol-http": "^4.1.8",
+            "@smithy/querystring-builder": "^3.0.11",
+            "@smithy/types": "^3.7.2",
+            "@smithy/util-base64": "^3.0.0",
+            "tslib": "^2.6.2"
+          }
+        },
         "@smithy/is-array-buffer": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
           "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
           "requires": {
             "tslib": "^2.6.2"
           }
@@ -26769,101 +23816,6 @@
           "requires": {
             "@smithy/util-buffer-from": "^3.0.0",
             "tslib": "^2.6.2"
-          }
-        }
-      }
-    },
-    "@smithy/util-stream-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream-node/-/util-stream-node-1.1.0.tgz",
-      "integrity": "sha512-gC7La6Xh/Q6ruY2tF2kSmVYxZpca9nKMYsbPSNDUv6EKW6kMHO3UqxTQ4kixynUOz2uZ3igvuX+1d2w+LaD2dw==",
-      "dev": true,
-      "requires": {
-        "@smithy/node-http-handler": "^1.1.0",
-        "@smithy/types": "^1.2.0",
-        "@smithy/util-buffer-from": "^1.1.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@smithy/abort-controller": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
-          "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
-          "dev": true,
-          "requires": {
-            "@smithy/types": "^1.2.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.1.0.tgz",
-          "integrity": "sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/node-http-handler": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
-          "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
-          "dev": true,
-          "requires": {
-            "@smithy/abort-controller": "^1.1.0",
-            "@smithy/protocol-http": "^1.2.0",
-            "@smithy/querystring-builder": "^1.1.0",
-            "@smithy/types": "^1.2.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
-          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
-          "dev": true,
-          "requires": {
-            "@smithy/types": "^1.2.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/querystring-builder": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
-          "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
-          "dev": true,
-          "requires": {
-            "@smithy/types": "^1.2.0",
-            "@smithy/util-uri-escape": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
-          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.1.0.tgz",
-          "integrity": "sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==",
-          "dev": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^1.1.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-uri-escape": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
-          "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.5.0"
           }
         }
       }
@@ -26893,16 +23845,6 @@
         "@smithy/abort-controller": "^3.1.1",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@tapjs/after": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
     "@infrascan/informational-serializer": "^0.2.0",
     "@infrascan/sdk": "^0.6.0",
     "@rushstack/ts-command-line": "^4.15.2",
-    "@smithy/shared-ini-file-loader": "^2.2.2",
+    "@smithy/shared-ini-file-loader": "^3.1.12",
     "ejs": "^3.1.9",
     "minimatch": "^6.1.6",
     "open": "^10.1.0"
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@aws-sdk/types": "3.609.0",
     "@infrascan/shared-types": "^0.7.0",
-    "@smithy/types": "^2.4.0",
+    "@smithy/types": "^3.3.0",
     "@types/ejs": "^3.1.5",
     "ts-node": "^10.9.1",
     "typescript": "^5.4.5"

--- a/packages/s3-connector/package.json
+++ b/packages/s3-connector/package.json
@@ -31,7 +31,7 @@
   "author": "Liam Farrelly <liam@l3f7.dev> (https://whoisli.am/)",
   "license": "MPL-2.0",
   "devDependencies": {
-    "@aws-sdk/util-stream-node": "^3.374.0",
+    "@smithy/util-stream": "^3.3.4",
     "@infrascan/shared-types": "^0.7.0",
     "aws-sdk-client-mock": "^3.0.0",
     "eslint-config-custom": "*",

--- a/packages/s3-connector/src/index.test.ts
+++ b/packages/s3-connector/src/index.test.ts
@@ -7,7 +7,7 @@ import {
   S3Client,
 } from "@aws-sdk/client-s3";
 import t from "tap";
-import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
+import { sdkStreamMixin } from "@smithy/util-stream";
 import { resolve as resolvePath } from "path";
 import S3Connector from ".";
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/client-iam": "3.624.0",
     "@aws-sdk/client-sts": "3.624.0",
     "@infrascan/core": "^0.5.0",
-    "@smithy/util-retry": "^2.0.5",
+    "@smithy/util-retry": "^3.0.1",
     "debug": "^4",
     "jmespath": "^0.16.0",
     "minimatch": "^5.1.0"


### PR DESCRIPTION
Update dependencies on AWS internal utility packages to a consistent version to prevent type mismatches during testing.