### PR TITLE
Use uuid for id on event source informational node

### DIFF
--- a/.changeset/thirty-pigs-admire.md
+++ b/.changeset/thirty-pigs-admire.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/aws-lambda-scanner": minor
+---
+
+Change order of UUID and EventSourceArn for Lambda Event Source Mapping informational nodes. This should prevent conflict from the event sources themselves during graphing.

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          
+
       - name: Install dependencies
         run: npm ci
 
@@ -37,8 +37,8 @@ jobs:
 
       - name: Create Version PR or Publish
         uses: changesets/action@v1
-        with: 
-          publish: npm run release
+        with:
+          publish: npm run change:publish
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/aws-scanners/lambda/src/graph.ts
+++ b/aws-scanners/lambda/src/graph.ts
@@ -362,8 +362,8 @@ export const LambdaEventSourceEntity: TranslatedEntity<
 
     $graph(val) {
       return {
-        id: val.EventSourceArn!,
-        label: val.UUID!,
+        id: val.UUID!,
+        label: val.EventSourceArn!,
         nodeClass: "informational",
         nodeType: LambdaEventSourceEntity.nodeType,
         parent: `${val.$metadata.account}-${val.$metadata.region}`,
@@ -393,8 +393,8 @@ export const LambdaEventSourceEntity: TranslatedEntity<
 
     resource(val) {
       return {
-        id: val.EventSourceArn!,
-        name: val.UUID!,
+        id: val.UUID!,
+        name: val.EventSourceArn!,
         category: LambdaEventSourceEntity.category,
         subcategory: LambdaEventSourceEntity.subcategory,
       };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint:all": "eslint .",
     "test": "turbo run test",
     "clean": "turbo run clean ; rm -rf node_modules",
-    "release": "turbo run test ; npx changeset publish"
+    "change:plan": "npx changeset",
+    "change:publish": "turbo run test ; npx changeset publish"
   }
 }


### PR DESCRIPTION
Informational nodes from the lambda event source mappings selectors used the event source arn as their ID. This conflicts with the resources themselves e.g. an SQS queue. 

The conflict introduced a bug when the lambda grapher was called before the event source itself, leading to the source node being ignored entirely causing a broken graph.

This is a breaking change for any consumer depending on the specific ID in place for an event source.