### PR TITLE
chore: improve release hygeine, no static credentials, use oidc

### DIFF
--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -13,27 +13,19 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      id-token: write
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Add .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create Version PR or Publish
         uses: changesets/action@v1


### PR DESCRIPTION
Previous releases used static credentials which is annoying to manage and has higher risk. Restrict all packages to be published using OIDC tokens.