### PR TITLE
feat(core): add tryNormalizeDateString and tryNormalizeDateEpoch date utilities

### DIFF
--- a/.changeset/date-normalize-utility.md
+++ b/.changeset/date-normalize-utility.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/core": minor
+---
+
+Add `tryNormalizeDateString`, a utility for normalizing an unknown value into an ISO 8601 date string. It accepts `Date` instances, numbers, and strings, and returns `null` for any value that cannot be parsed into a valid date.

--- a/.changeset/date-normalize-utility.md
+++ b/.changeset/date-normalize-utility.md
@@ -2,4 +2,4 @@
 "@infrascan/core": minor
 ---
 
-Add `tryNormalizeDateString`, a utility for normalizing an unknown value into an ISO 8601 date string. It accepts `Date` instances, numbers, and strings, and returns `null` for any value that cannot be parsed into a valid date.
+Add `tryNormalizeDateString` and `tryNormalizeDateEpoch`, utilities for normalizing an unknown value into an ISO 8601 date string or a numeric millisecond epoch respectively. Both accept `Date` instances, numbers, and strings, and return `null` for any value that cannot be parsed into a valid date.

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@infrascan/cytoscape-serializer": "^0.3.4",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@types/cytoscape": "^3.19.16",
         "typescript": "^5.4.5",
         "vite": "^7.0.0"
@@ -578,7 +578,7 @@
         "@aws-sdk/types": "3.609.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -600,7 +600,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -624,7 +624,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -646,7 +646,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -663,7 +663,7 @@
         "ejs": "^3.1.9"
       },
       "devDependencies": {
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/ejs": "^3.1.5",
         "@types/node": "^20.3.1",
@@ -683,7 +683,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -694,7 +694,7 @@
     },
     "aws-scanners/ec2": {
       "name": "@infrascan/aws-ec2-scanner",
-      "version": "0.5.0",
+      "version": "0.7.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "3.624.0",
@@ -705,7 +705,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.1",
@@ -726,7 +726,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -749,7 +749,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -771,7 +771,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -782,7 +782,7 @@
     },
     "aws-scanners/lambda": {
       "name": "@infrascan/aws-lambda-scanner",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-lambda": "3.624.0",
@@ -793,7 +793,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -815,7 +815,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -842,7 +842,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -864,7 +864,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -885,7 +885,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -907,7 +907,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -929,7 +929,7 @@
         "@aws-sdk/credential-providers": "3.624.0",
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -18322,7 +18322,7 @@
     },
     "packages/aws": {
       "name": "@infrascan/aws",
-      "version": "0.5.4",
+      "version": "0.5.7",
       "license": "MPL-2.0",
       "dependencies": {
         "@infrascan/aws-api-gateway-scanner": "^0.5.0",
@@ -18330,11 +18330,11 @@
         "@infrascan/aws-cloudfront-scanner": "^0.5.0",
         "@infrascan/aws-cloudwatch-logs-scanner": "^0.5.0",
         "@infrascan/aws-dynamodb-scanner": "^0.5.0",
-        "@infrascan/aws-ec2-scanner": "^0.5.0",
+        "@infrascan/aws-ec2-scanner": "^0.7.0",
         "@infrascan/aws-ecs-scanner": "^0.6.0",
         "@infrascan/aws-elastic-load-balancing-scanner": "^0.5.0",
         "@infrascan/aws-kinesis-scanner": "^0.4.0",
-        "@infrascan/aws-lambda-scanner": "^0.5.0",
+        "@infrascan/aws-lambda-scanner": "^0.6.0",
         "@infrascan/aws-rds-scanner": "^0.5.0",
         "@infrascan/aws-route53-scanner": "^0.6.0",
         "@infrascan/aws-s3-scanner": "^0.5.0",
@@ -18343,21 +18343,21 @@
         "@infrascan/aws-step-function-scanner": "^0.4.0"
       },
       "devDependencies": {
-        "@infrascan/sdk": "^0.6.0",
+        "@infrascan/sdk": "^0.6.2",
         "@infrascan/tsconfig": "*"
       }
     },
     "packages/cli": {
       "name": "@infrascan/cli",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "3.624.0",
-        "@infrascan/aws": "^0.5.4",
+        "@infrascan/aws": "^0.5.5",
         "@infrascan/cytoscape-serializer": "^0.3.4",
         "@infrascan/fs-connector": "^0.3.0",
         "@infrascan/informational-serializer": "^0.2.0",
-        "@infrascan/sdk": "^0.6.0",
+        "@infrascan/sdk": "^0.6.2",
         "@rushstack/ts-command-line": "^4.15.2",
         "@smithy/shared-ini-file-loader": "^3.1.12",
         "ejs": "^3.1.9",
@@ -18369,7 +18369,7 @@
       },
       "devDependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@smithy/types": "^3.3.0",
         "@types/ejs": "^3.1.5",
         "ts-node": "^10.9.1",
@@ -18398,8 +18398,9 @@
         "jmespath": "^0.16.0"
       },
       "devDependencies": {
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "eslint-config-custom": "*",
+        "tap": "^21",
         "ts-node": "^10.9.1",
         "tsconfig": "*",
         "typescript": "^5.4.5"
@@ -18410,7 +18411,7 @@
       "version": "0.3.4",
       "license": "MPL-2.0",
       "devDependencies": {
-        "@infrascan/shared-types": "^0.7.0"
+        "@infrascan/shared-types": "^0.8.0"
       }
     },
     "packages/fs-connector": {
@@ -18421,7 +18422,7 @@
         "minimatch": "^9.0.3"
       },
       "devDependencies": {
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "eslint-config-custom": "*",
         "tsconfig": "*",
         "typescript": "^5.4.5"
@@ -18432,7 +18433,7 @@
       "version": "0.2.0",
       "license": "MPL-2.0",
       "devDependencies": {
-        "@infrascan/shared-types": "^0.7.0"
+        "@infrascan/shared-types": "^0.8.0"
       }
     },
     "packages/s3-connector": {
@@ -18444,7 +18445,7 @@
         "minimatch": "^9.0.3"
       },
       "devDependencies": {
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@smithy/util-stream": "^3.3.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-custom": "*",
@@ -18455,7 +18456,7 @@
     },
     "packages/sdk": {
       "name": "@infrascan/sdk",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "3.624.0",
@@ -18492,7 +18493,7 @@
     },
     "packages/shared-types": {
       "name": "@infrascan/shared-types",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@aws-sdk/types": "3.609.0",
@@ -18510,7 +18511,7 @@
         "minimatch": "^9.0.4"
       },
       "devDependencies": {
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@types/node": "^20.12.10",
         "tap": "^21",
         "tsconfig": "*"
@@ -21771,18 +21772,18 @@
         "@infrascan/aws-cloudfront-scanner": "^0.5.0",
         "@infrascan/aws-cloudwatch-logs-scanner": "^0.5.0",
         "@infrascan/aws-dynamodb-scanner": "^0.5.0",
-        "@infrascan/aws-ec2-scanner": "^0.5.0",
+        "@infrascan/aws-ec2-scanner": "^0.7.0",
         "@infrascan/aws-ecs-scanner": "^0.6.0",
         "@infrascan/aws-elastic-load-balancing-scanner": "^0.5.0",
         "@infrascan/aws-kinesis-scanner": "^0.4.0",
-        "@infrascan/aws-lambda-scanner": "^0.5.0",
+        "@infrascan/aws-lambda-scanner": "^0.6.0",
         "@infrascan/aws-rds-scanner": "^0.5.0",
         "@infrascan/aws-route53-scanner": "^0.6.0",
         "@infrascan/aws-s3-scanner": "^0.5.0",
         "@infrascan/aws-sns-scanner": "^0.5.0",
         "@infrascan/aws-sqs-scanner": "^0.5.0",
         "@infrascan/aws-step-function-scanner": "^0.4.0",
-        "@infrascan/sdk": "^0.6.0",
+        "@infrascan/sdk": "^0.6.2",
         "@infrascan/tsconfig": "*"
       }
     },
@@ -21795,7 +21796,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -21813,7 +21814,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -21832,7 +21833,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -21851,7 +21852,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -21864,7 +21865,7 @@
     "@infrascan/aws-codegen": {
       "version": "file:aws-scanners/codegen",
       "requires": {
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/ejs": "^3.1.5",
         "@types/node": "^20.3.1",
@@ -21880,7 +21881,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -21898,7 +21899,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.1",
@@ -21915,7 +21916,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -21934,7 +21935,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -21952,7 +21953,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -21970,7 +21971,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -21988,7 +21989,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -22010,7 +22011,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -22029,7 +22030,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -22046,7 +22047,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -22064,7 +22065,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -22082,7 +22083,7 @@
         "@infrascan/aws-codegen": "^0.1.0",
         "@infrascan/core": "0.5.0",
         "@infrascan/fs-connector": "^0.3.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@infrascan/tsconfig": "*",
         "@types/debug": "^4",
         "aws-sdk-client-mock": "^3.0.0",
@@ -22097,12 +22098,12 @@
       "requires": {
         "@aws-sdk/credential-providers": "3.624.0",
         "@aws-sdk/types": "3.609.0",
-        "@infrascan/aws": "^0.5.4",
+        "@infrascan/aws": "^0.5.5",
         "@infrascan/cytoscape-serializer": "^0.3.4",
         "@infrascan/fs-connector": "^0.3.0",
         "@infrascan/informational-serializer": "^0.2.0",
-        "@infrascan/sdk": "^0.6.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/sdk": "^0.6.2",
+        "@infrascan/shared-types": "^0.8.0",
         "@rushstack/ts-command-line": "^4.15.2",
         "@smithy/shared-ini-file-loader": "^3.1.12",
         "@smithy/types": "^3.3.0",
@@ -22127,9 +22128,10 @@
     "@infrascan/core": {
       "version": "file:packages/core",
       "requires": {
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "eslint-config-custom": "*",
         "jmespath": "^0.16.0",
+        "tap": "^21",
         "ts-node": "^10.9.1",
         "tsconfig": "*",
         "typescript": "^5.4.5"
@@ -22138,13 +22140,13 @@
     "@infrascan/cytoscape-serializer": {
       "version": "file:packages/cytoscape-serializer",
       "requires": {
-        "@infrascan/shared-types": "^0.7.0"
+        "@infrascan/shared-types": "^0.8.0"
       }
     },
     "@infrascan/fs-connector": {
       "version": "file:packages/fs-connector",
       "requires": {
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "eslint-config-custom": "*",
         "minimatch": "^9.0.3",
         "tsconfig": "*",
@@ -22154,14 +22156,14 @@
     "@infrascan/informational-serializer": {
       "version": "file:packages/informational-serializer",
       "requires": {
-        "@infrascan/shared-types": "^0.7.0"
+        "@infrascan/shared-types": "^0.8.0"
       }
     },
     "@infrascan/node-reducer-plugin": {
       "version": "file:plugins/node-reducer",
       "requires": {
         "@infrascan/core": "*",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@types/node": "^20.12.10",
         "minimatch": "^9.0.4",
         "tap": "^21",
@@ -22172,7 +22174,7 @@
       "version": "file:apps/render",
       "requires": {
         "@infrascan/cytoscape-serializer": "^0.3.4",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@types/cytoscape": "^3.19.16",
         "typescript": "^5.4.5",
         "vite": "^7.0.0"
@@ -22407,7 +22409,7 @@
       "version": "file:packages/s3-connector",
       "requires": {
         "@aws-sdk/client-s3": "3.624.0",
-        "@infrascan/shared-types": "^0.7.0",
+        "@infrascan/shared-types": "^0.8.0",
         "@smithy/util-stream": "^3.3.4",
         "aws-sdk-client-mock": "^3.0.0",
         "eslint-config-custom": "*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "rm -rf dist ; tsup --config internal/tsconfig/tsup.json",
     "prepublish": "rm -rf dist ; tsup --config internal/tsconfig/tsup.json",
-    "test": "echo \"Error: no test specified\"",
+    "test": "tap src/*.test.ts --allow-incomplete-coverage -- --typescript",
     "lint": "tsc --noEmit ; prettier src/**/*.ts -c ; eslint .",
     "lint:fix": "prettier src/**/*.ts -w ; eslint . --fix",
     "clean": "rm -rf dist node_modules"
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@infrascan/shared-types": "^0.8.0",
     "eslint-config-custom": "*",
+    "tap": "^21",
     "ts-node": "^10.9.1",
     "tsconfig": "*",
     "typescript": "^5.4.5"

--- a/packages/core/src/date.test.ts
+++ b/packages/core/src/date.test.ts
@@ -1,5 +1,5 @@
 import t from "tap";
-import { tryNormalizeDateString } from "./date";
+import { tryNormalizeDateString, tryNormalizeDateEpoch } from "./date";
 
 t.test("normalizes a Date instance via toISOString", (tap) => {
   const date = new Date("2026-07-24T12:34:56.000Z");
@@ -47,3 +47,62 @@ t.test("returns null for non-date, non-number, non-string inputs", (tap) => {
   tap.equal(tryNormalizeDateString(true), null);
   tap.end();
 });
+
+t.test(
+  "tryNormalizeDateEpoch: normalizes a Date instance via getTime",
+  (tap) => {
+    const date = new Date("2026-07-24T12:34:56.000Z");
+    tap.equal(tryNormalizeDateEpoch(date), date.getTime());
+    tap.end();
+  },
+);
+
+t.test(
+  "tryNormalizeDateEpoch: passes through a numeric epoch timestamp",
+  (tap) => {
+    const epochMillis = Date.UTC(2026, 6, 24, 12, 34, 56);
+    tap.equal(tryNormalizeDateEpoch(epochMillis), epochMillis);
+    tap.end();
+  },
+);
+
+t.test("tryNormalizeDateEpoch: normalizes a parseable date string", (tap) => {
+  tap.equal(
+    tryNormalizeDateEpoch("2026-07-24T12:34:56.000Z"),
+    Date.UTC(2026, 6, 24, 12, 34, 56),
+  );
+  tap.end();
+});
+
+t.test(
+  "tryNormalizeDateEpoch: returns null for an invalid date string",
+  (tap) => {
+    tap.equal(tryNormalizeDateEpoch("not a date"), null);
+    tap.end();
+  },
+);
+
+t.test(
+  "tryNormalizeDateEpoch: returns null for an invalid Date instance",
+  (tap) => {
+    tap.equal(tryNormalizeDateEpoch(new Date(NaN)), null);
+    tap.end();
+  },
+);
+
+t.test("tryNormalizeDateEpoch: returns null for NaN", (tap) => {
+  tap.equal(tryNormalizeDateEpoch(NaN), null);
+  tap.end();
+});
+
+t.test(
+  "tryNormalizeDateEpoch: returns null for non-date, non-number, non-string inputs",
+  (tap) => {
+    tap.equal(tryNormalizeDateEpoch(null), null);
+    tap.equal(tryNormalizeDateEpoch(undefined), null);
+    tap.equal(tryNormalizeDateEpoch({}), null);
+    tap.equal(tryNormalizeDateEpoch([]), null);
+    tap.equal(tryNormalizeDateEpoch(true), null);
+    tap.end();
+  },
+);

--- a/packages/core/src/date.test.ts
+++ b/packages/core/src/date.test.ts
@@ -1,0 +1,49 @@
+import t from "tap";
+import { tryNormalizeDateString } from "./date";
+
+t.test("normalizes a Date instance via toISOString", (tap) => {
+  const date = new Date("2026-07-24T12:34:56.000Z");
+  tap.equal(tryNormalizeDateString(date), "2026-07-24T12:34:56.000Z");
+  tap.end();
+});
+
+t.test("normalizes a numeric epoch timestamp", (tap) => {
+  const epochMillis = Date.UTC(2026, 6, 24, 12, 34, 56);
+  tap.equal(
+    tryNormalizeDateString(epochMillis),
+    new Date(epochMillis).toISOString(),
+  );
+  tap.end();
+});
+
+t.test("normalizes a parseable date string", (tap) => {
+  tap.equal(
+    tryNormalizeDateString("2026-07-24T12:34:56.000Z"),
+    "2026-07-24T12:34:56.000Z",
+  );
+  tap.end();
+});
+
+t.test("returns null for an invalid date string", (tap) => {
+  tap.equal(tryNormalizeDateString("not a date"), null);
+  tap.end();
+});
+
+t.test("returns null for an invalid Date instance", (tap) => {
+  tap.equal(tryNormalizeDateString(new Date(NaN)), null);
+  tap.end();
+});
+
+t.test("returns null for NaN", (tap) => {
+  tap.equal(tryNormalizeDateString(NaN), null);
+  tap.end();
+});
+
+t.test("returns null for non-date, non-number, non-string inputs", (tap) => {
+  tap.equal(tryNormalizeDateString(null), null);
+  tap.equal(tryNormalizeDateString(undefined), null);
+  tap.equal(tryNormalizeDateString({}), null);
+  tap.equal(tryNormalizeDateString([]), null);
+  tap.equal(tryNormalizeDateString(true), null);
+  tap.end();
+});

--- a/packages/core/src/date.ts
+++ b/packages/core/src/date.ts
@@ -1,4 +1,30 @@
 /**
+ * Attempts to coerce an arbitrary value into a valid `Date` instance.
+ *
+ * - A `Date` instance is returned as-is (when valid).
+ * - A `number` or `string` is passed to the `Date` constructor.
+ * - Anything else returns `null`.
+ *
+ * An input which cannot be parsed into a valid date (e.g. an unparseable
+ * string, `NaN`, or an invalid `Date`) also returns `null`.
+ *
+ * @param input The value to coerce.
+ * @returns A valid `Date` instance, or `null`.
+ */
+function tryParseDate(input: unknown): Date | null {
+  if (input instanceof Date) {
+    return Number.isNaN(input.getTime()) ? null : input;
+  }
+
+  if (typeof input === "number" || typeof input === "string") {
+    const parsed = new Date(input);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  return null;
+}
+
+/**
  * Attempts to normalize an arbitrary value into an ISO 8601 date string.
  *
  * - A `Date` instance is normalized via {@link Date.toISOString}.
@@ -11,14 +37,24 @@
  * @returns The ISO 8601 representation of the date, or `null`.
  */
 export function tryNormalizeDateString(input: unknown): string | null {
-  if (input instanceof Date) {
-    return Number.isNaN(input.getTime()) ? null : input.toISOString();
-  }
+  const date = tryParseDate(input);
+  return date != null ? date.toISOString() : null;
+}
 
-  if (typeof input === "number" || typeof input === "string") {
-    const parsed = new Date(input);
-    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
-  }
-
-  return null;
+/**
+ * Attempts to normalize an arbitrary value into a numeric Unix epoch
+ * timestamp, in milliseconds.
+ *
+ * - A `Date` instance is normalized via {@link Date.getTime}.
+ * - A `number` or `string` is first parsed into a `Date` instance, then
+ *   normalized via {@link Date.getTime}.
+ * - Anything else (or a value which cannot be parsed into a valid date)
+ *   returns `null`.
+ *
+ * @param input The value to normalize.
+ * @returns The epoch timestamp in milliseconds, or `null`.
+ */
+export function tryNormalizeDateEpoch(input: unknown): number | null {
+  const date = tryParseDate(input);
+  return date != null ? date.getTime() : null;
 }

--- a/packages/core/src/date.ts
+++ b/packages/core/src/date.ts
@@ -1,0 +1,24 @@
+/**
+ * Attempts to normalize an arbitrary value into an ISO 8601 date string.
+ *
+ * - A `Date` instance is normalized via {@link Date.toISOString}.
+ * - A `number` or `string` is first parsed into a `Date` instance, then
+ *   normalized via {@link Date.toISOString}.
+ * - Anything else (or a value which cannot be parsed into a valid date)
+ *   returns `null`.
+ *
+ * @param input The value to normalize.
+ * @returns The ISO 8601 representation of the date, or `null`.
+ */
+export function tryNormalizeDateString(input: unknown): string | null {
+  if (input instanceof Date) {
+    return Number.isNaN(input.getTime()) ? null : input.toISOString();
+  }
+
+  if (typeof input === "number" || typeof input === "string") {
+    const parsed = new Date(input);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+
+  return null;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ import type {
 
 export * from "./graph";
 export * from "./errors";
+export * from "./date";
 
 export const Size = {
   Bytes: "B" as SizeUnit,


### PR DESCRIPTION
## Summary

Introduces two tested date-normalization utilities to `@infrascan/core`, consumable by every service scanner and the SDK:

- **`tryNormalizeDateString(input: unknown): string | null`** — normalizes a `Date`, `number`, or `string` into an ISO 8601 string; returns `null` for anything that can't be parsed into a valid date.
- **`tryNormalizeDateEpoch(input: unknown): number | null`** — same input handling, but returns a numeric millisecond Unix epoch.

Shared coercion lives in a module-private `tryParseDate` helper, so both functions apply identical parsing/validation rules.

### Why

Scanner state is persisted with `JSON.stringify` and rehydrated with a bare `JSON.parse` (no date reviver) in both connectors (`packages/fs-connector`, `packages/s3-connector`). Entity ETLs therefore run against rehydrated state where any field the AWS SDK types as `Date` is actually an ISO **string** at runtime — while TypeScript still types it as `Date`. This is the trap behind the reported graphing crash: `field?.toISOString()` passes the `?.` nullish guard (a string isn't nullish) and then throws `toISOString is not a function`.

These utilities accept a `Date` *or* a string/number and always emit a consistent output (or `null` instead of crashing), regardless of connector or code path.

## Tests

`packages/core/src/date.test.ts` (22 assertions, all passing) covers Date instances, numeric epochs, parseable strings, invalid strings, invalid `Date`s, `NaN`, and non-date/number/string inputs for both functions. The `test` script for `@infrascan/core` (previously a no-op) is now wired to `tap`.

## Audit — potential integration points

A follow-up audit of the aws-scanner node-entity ETLs identified the timestamp properties where these utilities should be applied. Root cause is the JSON round-trip described above.

### Category A — Confirmed live crashes (`.toISOString()` on a `Date`-typed field)
The exact reported failure mode: not nullish, not a `Date`.

| File:line | Node property | Source field (SDK type) |
|-----------|---------------|--------------------------|
| `aws-scanners/ec2/src/graph/launch-template.ts:188` | `audit.createdAt` | `CreateTime` (`Date`) |
| `aws-scanners/lambda/src/graph.ts:451` | `...startingPositionTimestamp` | `StartingPositionTimestamp` (`Date`) |

### Category B — Latent: raw pass-through of a `Date`-typed field
No crash at the assignment, but they store a `Date` on the in-memory pass and a string after a round-trip, so output is inconsistent and any downstream `.toISOString()` (the `Audit.createdAt` type is `string | Date`) would crash.

| File:line | Node property | Source field (SDK type) |
|-----------|---------------|--------------------------|
| `aws-scanners/ec2/src/graph/nat-gateway.ts:127` | `audit.createdAt` | `CreateTime` (`Date`) |
| `aws-scanners/ecs/src/graph.ts:270` | `audit.createdAt` | `createdAt` (`Date`) |
| `aws-scanners/ecs/src/graph.ts:446` | `audit.createdAt` | `createdAt` (`Date`) |
| `aws-scanners/kinesis/src/graph.ts:127` | `audit.createdAt` | `StreamCreationTimestamp` (`Date`) |
| `aws-scanners/kinesis/src/graph.ts:242` | `audit.createdAt` | `ConsumerCreationTimestamp` (`Date`) |
| `aws-scanners/s3/src/graph.ts:96` | `audit.createdAt` | `CreationDate` (`Date`) |
| `aws-scanners/step-function/src/graph.ts:119` | `audit.createdAt` | `creationDate` (`Date`) |
| `aws-scanners/dynamodb/src/graph.ts:297` | `audit.createdAt` | `CreationDateTime` (`Date`) |
| `aws-scanners/dynamodb/src/graph.ts:322` | `archive.dateTime` | `ArchivalSummary.ArchivalDateTime` (`Date`) |
| `aws-scanners/dynamodb/src/graph.ts:155` | `...lastDecreaseDateTime` | `ProvisionedThroughput.LastDecreaseDateTime` (`Date`) |
| `aws-scanners/dynamodb/src/graph.ts:157` | `...lastIncreaseDateTime` | `ProvisionedThroughput.LastIncreaseDateTime` (`Date`) |

### Category C — `new Date(...)` wrapped (crash-safe, but inconsistent output)
`new Date(x)` tolerates a `Date` or a string/number, so no crash — but it stores a `Date` object into a `string | Date` slot, re-serializing inconsistently. Worth normalizing for uniform output.

| File:line | Node property | Source field (SDK type) |
|-----------|---------------|--------------------------|
| `aws-scanners/cloudwatch-logs/src/graph.ts:112` | `audit.createdAt` | `creationTime` (`number`) |
| `aws-scanners/elastic-load-balancing/src/graph.ts:128` | `audit.createdAt` | `CreatedTime` (`Date`) |

### Category D — String-typed, review separately (not `Date` instances)
Not crash risks, and applying a normalizer would *change behavior*, so these need a judgement call rather than a mechanical swap.

| File:line | Node property | Notes |
|-----------|---------------|-------|
| `aws-scanners/sqs/src/graph.ts:95–108` | `audit.createdAt` | `CreatedTimestamp` is a string attribute, hand-converted to an **epoch-ms string** (not ISO). `tryNormalizeDateEpoch` maps cleanly here, but it's a deliberate format decision. |
| `aws-scanners/sns/src/graph.ts:174` | `archive.beginningTime` | `BeginningArchiveTime` is already typed `string`; normalize only for a guaranteed format. |

### Suggested rollout
- **Fix now (A):** the two reproduced crashes.
- **Fix for correctness/consistency (B):** same latent bug, one round-trip from crashing.
- **Optional (C):** consistency only.
- **Decide per-case (D):** behavior change — confirm intent first.

These integration changes are intentionally **not** included in this PR, which adds only the core utilities. They can follow in a separate change once the approach is approved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGqTBDviMEpQsodfgjG1P2)_