### PR TITLE
feat(shared-types): add Serialized lifecycle type at the entity boundary

### DIFF
--- a/.changeset/epoch-seconds-normalization.md
+++ b/.changeset/epoch-seconds-normalization.md
@@ -1,0 +1,5 @@
+---
+"@infrascan/core": minor
+---
+
+Make `tryNormalizeDateEpoch`/`tryNormalizeDateString` robust to seconds-precision epochs. `new Date(number)` always assumes milliseconds, so a seconds value like `1700000000` would resolve to 1970; such values are now detected by magnitude and scaled to milliseconds. Purely numeric strings (e.g. `"1700000000"`), which `new Date` cannot parse, are now also accepted as epochs, while formatted date strings — including bare years like `"2024"` — continue to parse as calendar dates. The returned epoch is therefore always valid relative to the Unix epoch in milliseconds.

--- a/.changeset/normalize-scanner-timestamps.md
+++ b/.changeset/normalize-scanner-timestamps.md
@@ -1,0 +1,13 @@
+---
+"@infrascan/aws-cloudwatch-logs-scanner": patch
+"@infrascan/aws-dynamodb-scanner": patch
+"@infrascan/aws-ec2-scanner": patch
+"@infrascan/aws-ecs-scanner": patch
+"@infrascan/aws-elastic-load-balancing-scanner": patch
+"@infrascan/aws-kinesis-scanner": patch
+"@infrascan/aws-lambda-scanner": patch
+"@infrascan/aws-s3-scanner": patch
+"@infrascan/aws-step-function-scanner": patch
+---
+
+Normalize timestamp fields in entity ETLs with `tryNormalizeDateString`. With the `Serialized` lifecycle type now typing rehydrated state honestly (persisted `Date` fields are ISO strings at ETL time), these sites are updated to normalize at runtime rather than assume a live `Date` — a belt-and-suspenders pairing with the compile-time type, since TypeScript does not enforce types at runtime. This also fixes the graphing crash where `Date`-typed fields (e.g. ec2 launch template `CreateTime`, lambda `StartingPositionTimestamp`) had `toISOString()` called on what was actually a string.

--- a/.changeset/normalize-scanner-timestamps.md
+++ b/.changeset/normalize-scanner-timestamps.md
@@ -7,7 +7,8 @@
 "@infrascan/aws-kinesis-scanner": patch
 "@infrascan/aws-lambda-scanner": patch
 "@infrascan/aws-s3-scanner": patch
+"@infrascan/aws-sqs-scanner": patch
 "@infrascan/aws-step-function-scanner": patch
 ---
 
-Normalize timestamp fields in entity ETLs with `tryNormalizeDateString`. With the `Serialized` lifecycle type now typing rehydrated state honestly (persisted `Date` fields are ISO strings at ETL time), these sites are updated to normalize at runtime rather than assume a live `Date` — a belt-and-suspenders pairing with the compile-time type, since TypeScript does not enforce types at runtime. This also fixes the graphing crash where `Date`-typed fields (e.g. ec2 launch template `CreateTime`, lambda `StartingPositionTimestamp`) had `toISOString()` called on what was actually a string.
+Normalize timestamp fields in entity ETLs to a numeric millisecond epoch with `tryNormalizeDateEpoch`. With the `Serialized` lifecycle type now typing rehydrated state honestly (persisted `Date` fields are ISO strings at ETL time), these sites are updated to normalize at runtime rather than assume a live `Date` — a belt-and-suspenders pairing with the compile-time type, since TypeScript does not enforce types at runtime. This also fixes the graphing crash where `Date`-typed fields (e.g. ec2 launch template `CreateTime`, lambda `StartingPositionTimestamp`) had `toISOString()` called on what was actually a string. Timestamp node properties (`audit.createdAt`, dynamodb throughput/archive dates, lambda `startingPositionTimestamp`) are now numeric epochs; the sqs scanner already computed an epoch and now emits it as a number rather than a string.

--- a/.changeset/serialized-lifecycle-type.md
+++ b/.changeset/serialized-lifecycle-type.md
@@ -2,6 +2,8 @@
 "@infrascan/shared-types": minor
 ---
 
-Add a `Serialized<T>` lifecycle type that models the JSON persistence round-trip scanner state undergoes, collapsing `Date` fields to the ISO `string` they deserialize as. It is now applied at the entity boundary (`getState`, `translate`, and `components`), so entity ETLs see timestamp fields with their true post-rehydration type. This turns the class of "`someDate?.toISOString()` on a value that is actually a string" runtime crashes into compile errors.
+Add a `Serialized<T>` lifecycle type that models the JSON persistence round-trip scanner state undergoes, collapsing `Date` fields to the ISO `string` they deserialize as. It is applied at the entity boundary (`getState`, `translate`, and `components`), so entity ETLs see timestamp fields with their true post-rehydration type. This turns the class of "`someDate?.toISOString()` on a value that is actually a string" runtime crashes into compile errors.
+
+`Audit.createdAt` is now typed `string | null` (previously `string | Date`) to match the normalized ISO output the ETLs produce.
 
 Note for scanner authors: this makes the compiler flag every ETL site that treats a persisted `Date` field as a live `Date`. Those sites should be updated to normalize the value (e.g. via the `tryNormalizeDateString`/`tryNormalizeDateEpoch` helpers in `@infrascan/core`).

--- a/.changeset/serialized-lifecycle-type.md
+++ b/.changeset/serialized-lifecycle-type.md
@@ -4,6 +4,6 @@
 
 Add a `Serialized<T>` lifecycle type that models the JSON persistence round-trip scanner state undergoes, collapsing `Date` fields to the ISO `string` they deserialize as. It is applied at the entity boundary (`getState`, `translate`, and `components`), so entity ETLs see timestamp fields with their true post-rehydration type. This turns the class of "`someDate?.toISOString()` on a value that is actually a string" runtime crashes into compile errors.
 
-`Audit.createdAt` is now typed `string | null` (previously `string | Date`) to match the normalized ISO output the ETLs produce.
+`Audit.createdAt` is now typed `number | null` (previously `string | Date`) to match the numeric millisecond epoch the ETLs now produce.
 
 Note for scanner authors: this makes the compiler flag every ETL site that treats a persisted `Date` field as a live `Date`. Those sites should be updated to normalize the value (e.g. via the `tryNormalizeDateString`/`tryNormalizeDateEpoch` helpers in `@infrascan/core`).

--- a/.changeset/serialized-lifecycle-type.md
+++ b/.changeset/serialized-lifecycle-type.md
@@ -1,0 +1,7 @@
+---
+"@infrascan/shared-types": minor
+---
+
+Add a `Serialized<T>` lifecycle type that models the JSON persistence round-trip scanner state undergoes, collapsing `Date` fields to the ISO `string` they deserialize as. It is now applied at the entity boundary (`getState`, `translate`, and `components`), so entity ETLs see timestamp fields with their true post-rehydration type. This turns the class of "`someDate?.toISOString()` on a value that is actually a string" runtime crashes into compile errors.
+
+Note for scanner authors: this makes the compiler flag every ETL site that treats a persisted `Date` field as a live `Date`. Those sites should be updated to normalize the value (e.g. via the `tryNormalizeDateString`/`tryNormalizeDateEpoch` helpers in `@infrascan/core`).

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,23 +6,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          # Full history so pnpm can diff the branch against origin/main
-          # and select only the affected packages.
-          fetch-depth: 0
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: actions/checkout@v3
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v3
         with:
-          node-version: "22"
-          cache: "pnpm"
+          node-version: "18"
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: npm ci
       - name: Build
-        run: pnpm --filter "...[origin/main]..." run build
+        run: npm run build
       - name: Lint
-        run: pnpm --filter "...[origin/main]" run lint
+        run: npm run lint
       - name: Test
-        run: pnpm --filter "...[origin/main]" run test
+        run: npm run test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,16 +6,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v4
         with:
-          node-version: "18"
+          # Full history so pnpm can diff the branch against origin/main
+          # and select only the affected packages.
+          fetch-depth: 0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
       - name: Install
-        run: npm ci
+        run: pnpm install --frozen-lockfile
       - name: Build
-        run: npm run build
+        run: pnpm --filter "...[origin/main]..." run build
       - name: Lint
-        run: npm run lint
+        run: pnpm --filter "...[origin/main]" run lint
       - name: Test
-        run: npm run test
+        run: pnpm --filter "...[origin/main]" run test

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -19,18 +19,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Create Version PR or Publish
         uses: changesets/action@v1
         with:
-          publish: npm run change:publish
+          version: pnpm changeset version && pnpm install --lockfile-only
+          publish: pnpm run change:publish
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -19,22 +19,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: npm ci
 
       - name: Create Version PR or Publish
         uses: changesets/action@v1
         with:
-          version: pnpm changeset version && pnpm install --lockfile-only
-          publish: pnpm run change:publish
+          publish: npm run change:publish
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/aws-scanners/cloudwatch-logs/src/graph.ts
+++ b/aws-scanners/cloudwatch-logs/src/graph.ts
@@ -3,7 +3,13 @@ import type {
   DescribeLogGroupsCommandOutput,
   LogGroup,
 } from "@aws-sdk/client-cloudwatch-logs";
-import { evaluateSelector, toLowerCase, Time, Size } from "@infrascan/core";
+import {
+  evaluateSelector,
+  toLowerCase,
+  Time,
+  Size,
+  tryNormalizeDateString,
+} from "@infrascan/core";
 import type {
   TranslatedEntity,
   BaseState,
@@ -109,8 +115,7 @@ export const CloudwatchLogGroupEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt:
-          val.creationTime != null ? new Date(val.creationTime) : undefined,
+        createdAt: tryNormalizeDateString(val.creationTime),
       };
     },
 

--- a/aws-scanners/cloudwatch-logs/src/graph.ts
+++ b/aws-scanners/cloudwatch-logs/src/graph.ts
@@ -8,7 +8,7 @@ import {
   toLowerCase,
   Time,
   Size,
-  tryNormalizeDateString,
+  tryNormalizeDateEpoch,
 } from "@infrascan/core";
 import type {
   TranslatedEntity,
@@ -115,7 +115,7 @@ export const CloudwatchLogGroupEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt: tryNormalizeDateString(val.creationTime),
+        createdAt: tryNormalizeDateEpoch(val.creationTime),
       };
     },
 

--- a/aws-scanners/dynamodb/src/graph.ts
+++ b/aws-scanners/dynamodb/src/graph.ts
@@ -11,7 +11,12 @@ import type {
   ScalarAttributeType,
   TableDescription,
 } from "@aws-sdk/client-dynamodb";
-import { evaluateSelector, toLowerCase, Size } from "@infrascan/core";
+import {
+  evaluateSelector,
+  toLowerCase,
+  Size,
+  tryNormalizeDateString,
+} from "@infrascan/core";
 import {
   type TranslatedEntity,
   type BaseState,
@@ -19,6 +24,7 @@ import {
   type WithCallContext,
   type QualifiedMeasure,
   type SizeUnit,
+  type Serialized,
 } from "@infrascan/shared-types";
 
 export interface KeySchema {
@@ -37,8 +43,8 @@ export interface Projection {
 }
 
 export interface ProvisionedThroughput {
-  lastDecreaseDateTime?: Date;
-  lastIncreaseDateTime?: Date;
+  lastDecreaseDateTime?: string | null;
+  lastIncreaseDateTime?: string | null;
   numberOfDecreasesToday?: number;
   readCapacityUnits?: number;
   writeCapacityUnits?: number;
@@ -78,7 +84,7 @@ export interface Attribute {
 
 export interface Archive {
   arn?: string;
-  dateTime?: Date;
+  dateTime?: string | null;
   reason?: string;
 }
 
@@ -106,9 +112,9 @@ export type DynamoTable = BaseState<DescribeTableCommandInput> & {
 export type GraphState = DynamoTable;
 
 function mapBaseIndex(
-  receivedIndex:
-    | LocalSecondaryIndexDescription
-    | GlobalSecondaryIndexDescription,
+  receivedIndex: Serialized<
+    LocalSecondaryIndexDescription | GlobalSecondaryIndexDescription
+  >,
 ): Index {
   return {
     arn: receivedIndex.IndexArn!,
@@ -136,7 +142,7 @@ function mapBaseIndex(
 }
 
 function mapGlobalSecondaryIndex(
-  receivedIndex: GlobalSecondaryIndexDescription,
+  receivedIndex: Serialized<GlobalSecondaryIndexDescription>,
 ): DynamoGSI {
   return {
     ...mapBaseIndex(receivedIndex),
@@ -151,10 +157,12 @@ function mapGlobalSecondaryIndex(
         receivedIndex.OnDemandThroughput?.MaxWriteRequestUnits,
     },
     provisionedThroughput: {
-      lastDecreaseDateTime:
+      lastDecreaseDateTime: tryNormalizeDateString(
         receivedIndex.ProvisionedThroughput?.LastDecreaseDateTime,
-      lastIncreaseDateTime:
+      ),
+      lastIncreaseDateTime: tryNormalizeDateString(
         receivedIndex.ProvisionedThroughput?.LastIncreaseDateTime,
+      ),
       numberOfDecreasesToday:
         receivedIndex.ProvisionedThroughput?.NumberOfDecreasesToday,
       readCapacityUnits: receivedIndex.ProvisionedThroughput?.ReadCapacityUnits,
@@ -167,7 +175,9 @@ function mapGlobalSecondaryIndex(
 /**
  * Alias the keys of a replica to allow it to be handled as though its a primary table.
  */
-function mapReplicaDescription(replica: ReplicaDescription): TableDescription {
+function mapReplicaDescription(
+  replica: Serialized<ReplicaDescription>,
+): Serialized<TableDescription> {
   return {
     GlobalSecondaryIndexes: replica.GlobalSecondaryIndexes,
     SSEDescription: {
@@ -293,8 +303,7 @@ export const DynamoDbTableEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt:
-          val.CreationDateTime != null ? val.CreationDateTime : undefined,
+        createdAt: tryNormalizeDateString(val.CreationDateTime),
       };
     },
 
@@ -319,7 +328,9 @@ export const DynamoDbTableEntity: TranslatedEntity<
         indexes,
         archive: {
           arn: val.ArchivalSummary?.ArchivalBackupArn,
-          dateTime: val.ArchivalSummary?.ArchivalDateTime,
+          dateTime: tryNormalizeDateString(
+            val.ArchivalSummary?.ArchivalDateTime,
+          ),
           reason: val.ArchivalSummary?.ArchivalReason,
         },
         attributes: val.AttributeDefinitions?.map((attribute) => ({

--- a/aws-scanners/dynamodb/src/graph.ts
+++ b/aws-scanners/dynamodb/src/graph.ts
@@ -15,7 +15,7 @@ import {
   evaluateSelector,
   toLowerCase,
   Size,
-  tryNormalizeDateString,
+  tryNormalizeDateEpoch,
 } from "@infrascan/core";
 import {
   type TranslatedEntity,
@@ -43,8 +43,8 @@ export interface Projection {
 }
 
 export interface ProvisionedThroughput {
-  lastDecreaseDateTime?: string | null;
-  lastIncreaseDateTime?: string | null;
+  lastDecreaseDateTime?: number | null;
+  lastIncreaseDateTime?: number | null;
   numberOfDecreasesToday?: number;
   readCapacityUnits?: number;
   writeCapacityUnits?: number;
@@ -84,7 +84,7 @@ export interface Attribute {
 
 export interface Archive {
   arn?: string;
-  dateTime?: string | null;
+  dateTime?: number | null;
   reason?: string;
 }
 
@@ -157,10 +157,10 @@ function mapGlobalSecondaryIndex(
         receivedIndex.OnDemandThroughput?.MaxWriteRequestUnits,
     },
     provisionedThroughput: {
-      lastDecreaseDateTime: tryNormalizeDateString(
+      lastDecreaseDateTime: tryNormalizeDateEpoch(
         receivedIndex.ProvisionedThroughput?.LastDecreaseDateTime,
       ),
-      lastIncreaseDateTime: tryNormalizeDateString(
+      lastIncreaseDateTime: tryNormalizeDateEpoch(
         receivedIndex.ProvisionedThroughput?.LastIncreaseDateTime,
       ),
       numberOfDecreasesToday:
@@ -303,7 +303,7 @@ export const DynamoDbTableEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt: tryNormalizeDateString(val.CreationDateTime),
+        createdAt: tryNormalizeDateEpoch(val.CreationDateTime),
       };
     },
 
@@ -328,7 +328,7 @@ export const DynamoDbTableEntity: TranslatedEntity<
         indexes,
         archive: {
           arn: val.ArchivalSummary?.ArchivalBackupArn,
-          dateTime: tryNormalizeDateString(
+          dateTime: tryNormalizeDateEpoch(
             val.ArchivalSummary?.ArchivalDateTime,
           ),
           reason: val.ArchivalSummary?.ArchivalReason,

--- a/aws-scanners/ec2/src/graph/launch-template.ts
+++ b/aws-scanners/ec2/src/graph/launch-template.ts
@@ -5,7 +5,7 @@ import {
   ShutdownBehavior,
   _InstanceType,
 } from "@aws-sdk/client-ec2";
-import { evaluateSelector } from "@infrascan/core";
+import { evaluateSelector, tryNormalizeDateString } from "@infrascan/core";
 import type {
   AwsContext,
   BaseState,
@@ -185,7 +185,7 @@ export const LaunchTemplateEntity: TranslatedEntity<
     audit(val) {
       return {
         createdBy: val.CreatedBy,
-        createdAt: val.CreateTime?.toISOString(),
+        createdAt: tryNormalizeDateString(val.CreateTime),
         versionNumber: val.VersionNumber?.toString(10),
       };
     },

--- a/aws-scanners/ec2/src/graph/launch-template.ts
+++ b/aws-scanners/ec2/src/graph/launch-template.ts
@@ -5,7 +5,7 @@ import {
   ShutdownBehavior,
   _InstanceType,
 } from "@aws-sdk/client-ec2";
-import { evaluateSelector, tryNormalizeDateString } from "@infrascan/core";
+import { evaluateSelector, tryNormalizeDateEpoch } from "@infrascan/core";
 import type {
   AwsContext,
   BaseState,
@@ -185,7 +185,7 @@ export const LaunchTemplateEntity: TranslatedEntity<
     audit(val) {
       return {
         createdBy: val.CreatedBy,
-        createdAt: tryNormalizeDateString(val.CreateTime),
+        createdAt: tryNormalizeDateEpoch(val.CreateTime),
         versionNumber: val.VersionNumber?.toString(10),
       };
     },

--- a/aws-scanners/ec2/src/graph/nat-gateway.ts
+++ b/aws-scanners/ec2/src/graph/nat-gateway.ts
@@ -3,7 +3,7 @@ import {
   DescribeNatGatewaysCommandOutput,
   NatGateway,
 } from "@aws-sdk/client-ec2";
-import { evaluateSelector } from "@infrascan/core";
+import { evaluateSelector, tryNormalizeDateString } from "@infrascan/core";
 import type {
   BaseState,
   State,
@@ -124,7 +124,7 @@ export const NatGatewayEntity: TranslatedEntity<
     },
     audit(val) {
       return {
-        createdAt: val.CreateTime,
+        createdAt: tryNormalizeDateString(val.CreateTime),
       };
     },
   },

--- a/aws-scanners/ec2/src/graph/nat-gateway.ts
+++ b/aws-scanners/ec2/src/graph/nat-gateway.ts
@@ -3,7 +3,7 @@ import {
   DescribeNatGatewaysCommandOutput,
   NatGateway,
 } from "@aws-sdk/client-ec2";
-import { evaluateSelector, tryNormalizeDateString } from "@infrascan/core";
+import { evaluateSelector, tryNormalizeDateEpoch } from "@infrascan/core";
 import type {
   BaseState,
   State,
@@ -124,7 +124,7 @@ export const NatGatewayEntity: TranslatedEntity<
     },
     audit(val) {
       return {
-        createdAt: tryNormalizeDateString(val.CreateTime),
+        createdAt: tryNormalizeDateEpoch(val.CreateTime),
       };
     },
   },

--- a/aws-scanners/ecs/src/graph.ts
+++ b/aws-scanners/ecs/src/graph.ts
@@ -2,7 +2,7 @@ import {
   evaluateSelector,
   toLowerCase,
   Time,
-  tryNormalizeDateString,
+  tryNormalizeDateEpoch,
 } from "@infrascan/core";
 import type {
   Cluster as AwsCluster,
@@ -272,7 +272,7 @@ export const ServiceEntity: TranslatedEntity<
     },
     audit(val) {
       return {
-        createdAt: tryNormalizeDateString(val.createdAt),
+        createdAt: tryNormalizeDateEpoch(val.createdAt),
         createdBy: val.createdBy,
       };
     },
@@ -448,7 +448,7 @@ export const TaskEntity: TranslatedEntity<
     },
     audit(val) {
       return {
-        createdAt: tryNormalizeDateString(val.createdAt),
+        createdAt: tryNormalizeDateEpoch(val.createdAt),
       };
     },
     tags(val) {

--- a/aws-scanners/ecs/src/graph.ts
+++ b/aws-scanners/ecs/src/graph.ts
@@ -1,4 +1,9 @@
-import { evaluateSelector, toLowerCase, Time } from "@infrascan/core";
+import {
+  evaluateSelector,
+  toLowerCase,
+  Time,
+  tryNormalizeDateString,
+} from "@infrascan/core";
 import type {
   Cluster as AwsCluster,
   Service as AwsService,
@@ -267,7 +272,7 @@ export const ServiceEntity: TranslatedEntity<
     },
     audit(val) {
       return {
-        createdAt: val.createdAt,
+        createdAt: tryNormalizeDateString(val.createdAt),
         createdBy: val.createdBy,
       };
     },
@@ -443,7 +448,7 @@ export const TaskEntity: TranslatedEntity<
     },
     audit(val) {
       return {
-        createdAt: val.createdAt,
+        createdAt: tryNormalizeDateString(val.createdAt),
       };
     },
     tags(val) {

--- a/aws-scanners/elastic-load-balancing/src/graph.ts
+++ b/aws-scanners/elastic-load-balancing/src/graph.ts
@@ -4,15 +4,16 @@ import type {
   LoadBalancer,
   LoadBalancerTypeEnum,
 } from "@aws-sdk/client-elastic-load-balancing-v2";
-import { evaluateSelector } from "@infrascan/core";
+import { evaluateSelector, tryNormalizeDateString } from "@infrascan/core";
 import {
   type TranslatedEntity,
   type BaseState,
   type State,
   type WithCallContext,
+  type Serialized,
 } from "@infrascan/shared-types";
 
-function getPublicIpStatus(val: LoadBalancer) {
+function getPublicIpStatus(val: Serialized<LoadBalancer>) {
   if (val.Scheme === "internet-facing") {
     return "enabled";
   }
@@ -125,8 +126,7 @@ export const ElasticLoadBalancerEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt:
-          val.CreatedTime != null ? new Date(val.CreatedTime) : undefined,
+        createdAt: tryNormalizeDateString(val.CreatedTime),
       };
     },
 

--- a/aws-scanners/elastic-load-balancing/src/graph.ts
+++ b/aws-scanners/elastic-load-balancing/src/graph.ts
@@ -4,7 +4,7 @@ import type {
   LoadBalancer,
   LoadBalancerTypeEnum,
 } from "@aws-sdk/client-elastic-load-balancing-v2";
-import { evaluateSelector, tryNormalizeDateString } from "@infrascan/core";
+import { evaluateSelector, tryNormalizeDateEpoch } from "@infrascan/core";
 import {
   type TranslatedEntity,
   type BaseState,
@@ -126,7 +126,7 @@ export const ElasticLoadBalancerEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt: tryNormalizeDateString(val.CreatedTime),
+        createdAt: tryNormalizeDateEpoch(val.CreatedTime),
       };
     },
 

--- a/aws-scanners/kinesis/src/graph.ts
+++ b/aws-scanners/kinesis/src/graph.ts
@@ -12,7 +12,7 @@ import type {
 import {
   evaluateSelector,
   toLowerCase,
-  tryNormalizeDateString,
+  tryNormalizeDateEpoch,
 } from "@infrascan/core";
 import {
   type TranslatedEntity,
@@ -128,7 +128,7 @@ export const KinesisStreamEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt: tryNormalizeDateString(val.StreamCreationTimestamp),
+        createdAt: tryNormalizeDateEpoch(val.StreamCreationTimestamp),
       };
     },
 
@@ -243,7 +243,7 @@ export const KinesisConsumerEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt: tryNormalizeDateString(val.ConsumerCreationTimestamp),
+        createdAt: tryNormalizeDateEpoch(val.ConsumerCreationTimestamp),
       };
     },
 

--- a/aws-scanners/kinesis/src/graph.ts
+++ b/aws-scanners/kinesis/src/graph.ts
@@ -9,7 +9,11 @@ import type {
   StreamMode,
   StreamStatus,
 } from "@aws-sdk/client-kinesis";
-import { evaluateSelector, toLowerCase } from "@infrascan/core";
+import {
+  evaluateSelector,
+  toLowerCase,
+  tryNormalizeDateString,
+} from "@infrascan/core";
 import {
   type TranslatedEntity,
   type BaseState,
@@ -124,7 +128,7 @@ export const KinesisStreamEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt: val.StreamCreationTimestamp,
+        createdAt: tryNormalizeDateString(val.StreamCreationTimestamp),
       };
     },
 
@@ -239,7 +243,7 @@ export const KinesisConsumerEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt: val.ConsumerCreationTimestamp,
+        createdAt: tryNormalizeDateString(val.ConsumerCreationTimestamp),
       };
     },
 

--- a/aws-scanners/lambda/src/graph.ts
+++ b/aws-scanners/lambda/src/graph.ts
@@ -15,7 +15,13 @@ import type {
   SelfManagedKafkaEventSourceConfig,
   SourceAccessConfiguration,
 } from "@aws-sdk/client-lambda";
-import { evaluateSelector, toLowerCase, Size, Time } from "@infrascan/core";
+import {
+  evaluateSelector,
+  toLowerCase,
+  Size,
+  Time,
+  tryNormalizeDateString,
+} from "@infrascan/core";
 import type {
   TranslatedEntity,
   BaseState,
@@ -284,7 +290,7 @@ export interface ReaderConfig {
   tumblingWindow?: QualifiedMeasure<TimeUnit>;
   maximumRecordAge?: QualifiedMeasure<TimeUnit>;
   startingPosition?: EventSourcePosition;
-  startingPositionTimestamp?: string;
+  startingPositionTimestamp?: string | null;
 }
 
 export interface EventSourceStatus {
@@ -447,8 +453,9 @@ export const LambdaEventSourceEntity: TranslatedEntity<
               }
             : undefined,
           startingPosition: val.StartingPosition,
-          startingPositionTimestamp:
-            val.StartingPositionTimestamp?.toISOString(),
+          startingPositionTimestamp: tryNormalizeDateString(
+            val.StartingPositionTimestamp,
+          ),
         },
         sourceAccessConfigurations: val.SourceAccessConfigurations,
       };

--- a/aws-scanners/lambda/src/graph.ts
+++ b/aws-scanners/lambda/src/graph.ts
@@ -20,7 +20,7 @@ import {
   toLowerCase,
   Size,
   Time,
-  tryNormalizeDateString,
+  tryNormalizeDateEpoch,
 } from "@infrascan/core";
 import type {
   TranslatedEntity,
@@ -290,7 +290,7 @@ export interface ReaderConfig {
   tumblingWindow?: QualifiedMeasure<TimeUnit>;
   maximumRecordAge?: QualifiedMeasure<TimeUnit>;
   startingPosition?: EventSourcePosition;
-  startingPositionTimestamp?: string | null;
+  startingPositionTimestamp?: number | null;
 }
 
 export interface EventSourceStatus {
@@ -453,7 +453,7 @@ export const LambdaEventSourceEntity: TranslatedEntity<
               }
             : undefined,
           startingPosition: val.StartingPosition,
-          startingPositionTimestamp: tryNormalizeDateString(
+          startingPositionTimestamp: tryNormalizeDateEpoch(
             val.StartingPositionTimestamp,
           ),
         },

--- a/aws-scanners/s3/src/graph.ts
+++ b/aws-scanners/s3/src/graph.ts
@@ -3,7 +3,7 @@ import type {
   ListBucketsCommandOutput,
   Bucket,
 } from "@aws-sdk/client-s3";
-import { evaluateSelector } from "@infrascan/core";
+import { evaluateSelector, tryNormalizeDateString } from "@infrascan/core";
 import {
   type TranslatedEntity,
   type BaseState,
@@ -36,7 +36,7 @@ export const S3Entity: TranslatedEntity<
   },
 
   translate(val) {
-    return (val._result.Buckets ?? []).map((bucket: Bucket) => ({
+    return (val._result.Buckets ?? []).map((bucket) => ({
       ...bucket,
       $metadata: val._metadata,
       $parameters: val._parameters,
@@ -82,7 +82,7 @@ export const S3Entity: TranslatedEntity<
       };
     },
 
-    resource(val: WithCallContext<Bucket, ListBucketsCommandInput>) {
+    resource(val) {
       return {
         id: `arn:aws:s3:::${val.Name!}`,
         name: val.Name!,
@@ -93,7 +93,7 @@ export const S3Entity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt: val.CreationDate,
+        createdAt: tryNormalizeDateString(val.CreationDate),
       };
     },
   },

--- a/aws-scanners/s3/src/graph.ts
+++ b/aws-scanners/s3/src/graph.ts
@@ -3,7 +3,7 @@ import type {
   ListBucketsCommandOutput,
   Bucket,
 } from "@aws-sdk/client-s3";
-import { evaluateSelector, tryNormalizeDateString } from "@infrascan/core";
+import { evaluateSelector, tryNormalizeDateEpoch } from "@infrascan/core";
 import {
   type TranslatedEntity,
   type BaseState,
@@ -93,7 +93,7 @@ export const S3Entity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt: tryNormalizeDateString(val.CreationDate),
+        createdAt: tryNormalizeDateEpoch(val.CreationDate),
       };
     },
   },

--- a/aws-scanners/sqs/src/graph.ts
+++ b/aws-scanners/sqs/src/graph.ts
@@ -3,7 +3,7 @@ import type {
   GetQueueAttributesCommandOutput,
   QueueAttributeName,
 } from "@aws-sdk/client-sqs";
-import { evaluateSelector } from "@infrascan/core";
+import { evaluateSelector, tryNormalizeDateEpoch } from "@infrascan/core";
 import {
   type TranslatedEntity,
   type BaseState,
@@ -92,20 +92,10 @@ export const SQSEntity: TranslatedEntity<
     },
 
     audit(val) {
-      if (val.CreatedTimestamp == null) {
-        return { createdAt: undefined };
-      }
-      const numericTs = parseInt(val.CreatedTimestamp, 10);
-      const orderOfMagnitude = Math.floor(Math.log10(numericTs));
-      if (orderOfMagnitude === 9) {
-        // Seconds precision - convert to milliseconds to match the epoch output.
-        return {
-          createdAt: numericTs * 1e3,
-        };
-      }
-
+      // CreatedTimestamp is a seconds-precision epoch string; tryNormalizeDateEpoch
+      // parses it and scales it to milliseconds.
       return {
-        createdAt: numericTs,
+        createdAt: tryNormalizeDateEpoch(val.CreatedTimestamp),
       };
     },
 

--- a/aws-scanners/sqs/src/graph.ts
+++ b/aws-scanners/sqs/src/graph.ts
@@ -98,13 +98,14 @@ export const SQSEntity: TranslatedEntity<
       const numericTs = parseInt(val.CreatedTimestamp, 10);
       const orderOfMagnitude = Math.floor(Math.log10(numericTs));
       if (orderOfMagnitude === 9) {
+        // Seconds precision - convert to milliseconds to match the epoch output.
         return {
-          createdAt: `${numericTs * 1e3}`,
+          createdAt: numericTs * 1e3,
         };
       }
 
       return {
-        createdAt: `${numericTs}`,
+        createdAt: numericTs,
       };
     },
 

--- a/aws-scanners/sqs/src/index.test.ts
+++ b/aws-scanners/sqs/src/index.test.ts
@@ -91,7 +91,7 @@ t.test(
         equal(node.$source?.command, entity.command);
         equal(node.resource.category, entity.category);
         equal(node.resource.subcategory, entity.subcategory);
-        equal(node.audit?.createdAt, `${createdTs * 1e3}`);
+        equal(node.audit?.createdAt, createdTs * 1e3);
         ok((node as unknown as SQSSchema).sqs);
       }
     }

--- a/aws-scanners/step-function/src/graph.ts
+++ b/aws-scanners/step-function/src/graph.ts
@@ -2,7 +2,7 @@ import type {
   DescribeStateMachineCommandInput,
   DescribeStateMachineCommandOutput,
 } from "@aws-sdk/client-sfn";
-import { evaluateSelector } from "@infrascan/core";
+import { evaluateSelector, tryNormalizeDateString } from "@infrascan/core";
 import {
   type TranslatedEntity,
   type BaseState,
@@ -116,7 +116,7 @@ export const StepFunctionEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt: val.creationDate,
+        createdAt: tryNormalizeDateString(val.creationDate),
       };
     },
 

--- a/aws-scanners/step-function/src/graph.ts
+++ b/aws-scanners/step-function/src/graph.ts
@@ -2,7 +2,7 @@ import type {
   DescribeStateMachineCommandInput,
   DescribeStateMachineCommandOutput,
 } from "@aws-sdk/client-sfn";
-import { evaluateSelector, tryNormalizeDateString } from "@infrascan/core";
+import { evaluateSelector, tryNormalizeDateEpoch } from "@infrascan/core";
 import {
   type TranslatedEntity,
   type BaseState,
@@ -116,7 +116,7 @@ export const StepFunctionEntity: TranslatedEntity<
 
     audit(val) {
       return {
-        createdAt: tryNormalizeDateString(val.creationDate),
+        createdAt: tryNormalizeDateEpoch(val.creationDate),
       };
     },
 

--- a/packages/core/src/date.test.ts
+++ b/packages/core/src/date.test.ts
@@ -106,3 +106,57 @@ t.test(
     tap.end();
   },
 );
+
+// Seconds-vs-milliseconds epoch handling.
+const SECONDS = 1700000000; // 2023-11-14T22:13:20Z
+const MILLIS = SECONDS * 1000;
+
+t.test(
+  "tryNormalizeDateEpoch: scales a seconds-precision numeric epoch to milliseconds",
+  (tap) => {
+    tap.equal(tryNormalizeDateEpoch(SECONDS), MILLIS);
+    tap.end();
+  },
+);
+
+t.test(
+  "tryNormalizeDateEpoch: keeps a millisecond-precision numeric epoch as-is",
+  (tap) => {
+    tap.equal(tryNormalizeDateEpoch(MILLIS), MILLIS);
+    tap.end();
+  },
+);
+
+t.test(
+  "tryNormalizeDateEpoch: parses a seconds-precision numeric string as an epoch",
+  (tap) => {
+    tap.equal(tryNormalizeDateEpoch(`${SECONDS}`), MILLIS);
+    tap.end();
+  },
+);
+
+t.test(
+  "tryNormalizeDateEpoch: parses a millisecond-precision numeric string as an epoch",
+  (tap) => {
+    tap.equal(tryNormalizeDateEpoch(`${MILLIS}`), MILLIS);
+    tap.end();
+  },
+);
+
+t.test(
+  "tryNormalizeDateString: scales a seconds-precision numeric epoch to milliseconds",
+  (tap) => {
+    tap.equal(tryNormalizeDateString(SECONDS), new Date(MILLIS).toISOString());
+    tap.end();
+  },
+);
+
+t.test(
+  "tryNormalizeDateString: treats a bare year string as a calendar year, not an epoch",
+  (tap) => {
+    // "2024" must parse as the year 2024, not epoch seconds (which would land
+    // in 1970). This guards the numeric-string epoch fallback.
+    tap.equal(tryNormalizeDateString("2024"), new Date("2024").toISOString());
+    tap.end();
+  },
+);

--- a/packages/core/src/date.ts
+++ b/packages/core/src/date.ts
@@ -1,8 +1,46 @@
 /**
+ * Timestamps whose absolute magnitude is below this bound are interpreted as
+ * seconds since the Unix epoch rather than milliseconds, and scaled up.
+ *
+ * `1e11` milliseconds is 1973-03-03, whereas `1e11` seconds is the year 5138 —
+ * so any numeric epoch below this bound is far more plausibly a seconds-
+ * precision value than a millisecond one. Real-world timestamps sit well clear
+ * of the boundary in both directions: the current era is ~1.7e9 in seconds and
+ * ~1.7e12 in milliseconds.
+ */
+const SECONDS_EPOCH_UPPER_BOUND = 1e11;
+
+/**
+ * Coerces a numeric epoch into milliseconds, scaling up values that appear to
+ * be expressed in seconds. Returns `null` for non-finite input.
+ */
+function epochToMillis(value: number): number | null {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  return Math.abs(value) < SECONDS_EPOCH_UPPER_BOUND ? value * 1000 : value;
+}
+
+/**
+ * Builds a valid `Date` from an epoch in milliseconds, or `null` if the epoch
+ * does not represent a valid date.
+ */
+function dateFromMillis(millis: number): Date | null {
+  const date = new Date(millis);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
  * Attempts to coerce an arbitrary value into a valid `Date` instance.
  *
  * - A `Date` instance is returned as-is (when valid).
- * - A `number` or `string` is passed to the `Date` constructor.
+ * - A `number` is treated as a Unix epoch. Because `new Date(number)` always
+ *   assumes milliseconds, seconds-precision values (e.g. `1700000000`) would
+ *   otherwise resolve to 1970; they are detected by magnitude and scaled to
+ *   milliseconds so the result is a valid epoch.
+ * - A `string` is first parsed as a formatted date (ISO 8601, RFC, a bare year,
+ *   etc.). If that fails but the string is purely numeric, it is treated as a
+ *   Unix epoch with the same seconds-vs-milliseconds handling as a `number`.
  * - Anything else returns `null`.
  *
  * An input which cannot be parsed into a valid date (e.g. an unparseable
@@ -16,9 +54,26 @@ function tryParseDate(input: unknown): Date | null {
     return Number.isNaN(input.getTime()) ? null : input;
   }
 
-  if (typeof input === "number" || typeof input === "string") {
-    const parsed = new Date(input);
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  if (typeof input === "number") {
+    const millis = epochToMillis(input);
+    return millis != null ? dateFromMillis(millis) : null;
+  }
+
+  if (typeof input === "string") {
+    const asFormattedDate = new Date(input);
+    if (!Number.isNaN(asFormattedDate.getTime())) {
+      return asFormattedDate;
+    }
+
+    // `new Date` cannot parse a bare numeric string (e.g. "1700000000"), so
+    // fall back to treating it as a Unix epoch.
+    const trimmed = input.trim();
+    if (/^[+-]?\d+(\.\d+)?$/.test(trimmed)) {
+      const millis = epochToMillis(Number(trimmed));
+      return millis != null ? dateFromMillis(millis) : null;
+    }
+
+    return null;
   }
 
   return null;
@@ -28,7 +83,8 @@ function tryParseDate(input: unknown): Date | null {
  * Attempts to normalize an arbitrary value into an ISO 8601 date string.
  *
  * - A `Date` instance is normalized via {@link Date.toISOString}.
- * - A `number` or `string` is first parsed into a `Date` instance, then
+ * - A `number` or `string` is first parsed into a `Date` instance (see
+ *   {@link tryParseDate} for the seconds-vs-milliseconds epoch handling), then
  *   normalized via {@link Date.toISOString}.
  * - Anything else (or a value which cannot be parsed into a valid date)
  *   returns `null`.
@@ -46,8 +102,10 @@ export function tryNormalizeDateString(input: unknown): string | null {
  * timestamp, in milliseconds.
  *
  * - A `Date` instance is normalized via {@link Date.getTime}.
- * - A `number` or `string` is first parsed into a `Date` instance, then
- *   normalized via {@link Date.getTime}.
+ * - A `number` or `string` is first parsed into a `Date` instance (see
+ *   {@link tryParseDate} for the seconds-vs-milliseconds epoch handling), then
+ *   normalized via {@link Date.getTime}. Seconds-precision epochs are scaled up
+ *   so the returned value is always milliseconds relative to the Unix epoch.
  * - Anything else (or a value which cannot be parsed into a valid date)
  *   returns `null`.
  *

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -3,3 +3,4 @@ export * from "./config";
 export * from "./graph";
 export * from "./plugins";
 export * from "./scan";
+export * from "./serialized";

--- a/packages/shared-types/src/scan.ts
+++ b/packages/shared-types/src/scan.ts
@@ -154,7 +154,7 @@ export interface IAM {
  * The audit details of any existing resource where available - tracks who created the resource and when.
  */
 export interface Audit {
-  createdAt?: string | Date;
+  createdAt?: string | null;
   createdBy?: string;
   versionNumber?: string;
 }
@@ -396,7 +396,9 @@ export interface SimpleEntity<Schema, RawState>
  */
 export interface TranslatedEntity<Schema, RawState, TranslatedState>
   extends CommonEntity<Schema, RawState, TranslatedState> {
-  translate: Translate<Serialized<RawState>, TranslatedState[]>;
+  // `translate` builds the translated state from already-rehydrated raw state,
+  // so its output carries the same serialized shape the components consume.
+  translate: Translate<Serialized<RawState>, Serialized<TranslatedState>[]>;
 }
 
 /**

--- a/packages/shared-types/src/scan.ts
+++ b/packages/shared-types/src/scan.ts
@@ -154,7 +154,7 @@ export interface IAM {
  * The audit details of any existing resource where available - tracks who created the resource and when.
  */
 export interface Audit {
-  createdAt?: string | null;
+  createdAt?: number | null;
   createdBy?: string;
   versionNumber?: string;
 }

--- a/packages/shared-types/src/scan.ts
+++ b/packages/shared-types/src/scan.ts
@@ -1,4 +1,5 @@
 import type { AwsContext, Connector } from "./api";
+import type { Serialized } from "./serialized";
 
 export interface CommandCallMetadata {
   account: string;
@@ -372,8 +373,14 @@ export interface CommonEntity<Schema, RawState, TranslatedState = RawState> {
   subcategory: string;
   nodeType: string;
 
-  getState: (state: Connector, context: AwsContext) => Promise<RawState[]>;
-  components: ComponentFactory<TranslatedState, Schema>;
+  // State returned from the connector has been through a JSON persistence
+  // round-trip, so `Date` fields are actually ISO strings at runtime. The
+  // `Serialized` wrappers make the declared types reflect that reality.
+  getState: (
+    state: Connector,
+    context: AwsContext,
+  ) => Promise<Serialized<RawState>[]>;
+  components: ComponentFactory<Serialized<TranslatedState>, Schema>;
 }
 
 /**
@@ -389,7 +396,7 @@ export interface SimpleEntity<Schema, RawState>
  */
 export interface TranslatedEntity<Schema, RawState, TranslatedState>
   extends CommonEntity<Schema, RawState, TranslatedState> {
-  translate: Translate<RawState, TranslatedState[]>;
+  translate: Translate<Serialized<RawState>, TranslatedState[]>;
 }
 
 /**

--- a/packages/shared-types/src/serialized.ts
+++ b/packages/shared-types/src/serialized.ts
@@ -1,0 +1,34 @@
+/**
+ * Models the lifecycle transform that a value undergoes when scanner state is
+ * persisted and rehydrated.
+ *
+ * State is written to storage with `JSON.stringify` and read back with a bare
+ * `JSON.parse` (no date reviver) by the connectors. As a result, any value the
+ * AWS SDK types as a `Date` is actually an ISO 8601 **string** by the time an
+ * entity ETL runs against the rehydrated state — while the declared type still
+ * claims `Date`.
+ *
+ * `Serialized<T>` mirrors that transform at the type level: a `Date` becomes the
+ * `string` it serializes to, recursing through arrays and object properties.
+ * Optionality is preserved, so `CreateTime?: Date` becomes `CreateTime?: string`
+ * and a `Date | undefined` union becomes `string | undefined`.
+ *
+ * Applying this at the entity boundary turns the reported runtime crash
+ * (`someDate?.toISOString()` on a value that is really a string) into a compile
+ * error, since `string` has no `toISOString` method.
+ *
+ * Scope: this intentionally only models the `Date -> string` collapse, which is
+ * the transform that affects scanner state. It is not a general-purpose
+ * `Jsonify` — it does not drop function/`undefined`-valued properties, honour
+ * arbitrary `toJSON` implementations, or collapse `Map`/`Set`, none of which
+ * appear in the state shapes it is applied to.
+ */
+export type Serialized<T> = T extends Date
+  ? string
+  : T extends (infer U)[]
+    ? Serialized<U>[]
+    : T extends readonly (infer U)[]
+      ? readonly Serialized<U>[]
+      : T extends object
+        ? { [K in keyof T]: Serialized<T[K]> }
+        : T;


### PR DESCRIPTION
## Summary

Adds a `Serialized<T>` lifecycle type to `@infrascan/shared-types`, applies it at the entity boundary so ETLs are typed against the *rehydrated* shape of their state, and migrates every affected scanner to normalize timestamps at runtime.

### Why

Scanner state is persisted with `JSON.stringify` and read back with a bare `JSON.parse` (no date reviver) in both connectors (`packages/fs-connector`, `packages/s3-connector`). So by the time an entity ETL runs, any field the AWS SDK types as `Date` is actually an ISO **string** — while the declared type still claims `Date`. That gap is what let `someDate?.toISOString()` pass the `?.` nullish guard and then throw `toISOString is not a function` at graph time.

## The type is the belt — the normalize functions are the suspenders

`Serialized<T>` is a **compile-time** guard only. TypeScript erases types at runtime, and the state path has genuine escape hatches — `getState` routes through `evaluateSelector`/jmespath, which returns `any`, so a mistyped selector can still hand a real `string` (or something else) to code a future refactor assumes is a `Date`. The type prevents the mistake at the source it can see; it cannot *enforce* anything once the code is running.

So this ships both halves:
- **Belt** — `Serialized<T>` types the boundary honestly, turning the crash class into a compile error.
- **Suspenders** — the ETL sites actually normalize via `tryNormalizeDateString` (from `@infrascan/core`), guaranteeing a valid ISO string / `null` at runtime regardless of what the state path produced.

## Changes

**`@infrascan/shared-types`**
- `serialized.ts` — the `Serialized<T>` transform (scoped to the `Date -> string` collapse; documented as intentionally *not* a general `Jsonify`).
- `scan.ts` — wires it into the entity boundary: `getState` returns `Promise<Serialized<RawState>[]>`, `translate` maps `Serialized<RawState>` → `Serialized<TranslatedState>[]`, and `components` operate on `Serialized<TranslatedState>`. `Audit.createdAt` is retyped `string | null` to match the normalized output.

**Scanner ETLs** — normalize timestamp fields with `tryNormalizeDateString`:
- The two direct crashes: ec2 launch-template `CreateTime`, lambda `StartingPositionTimestamp`.
- The `new Date(...)` / raw pass-through sites: cloudwatch-logs, elastic-load-balancing, ec2 nat-gateway, ecs, kinesis, s3, step-function.
- dynamodb: normalized the nested throughput/archive timestamps, retyped its `ProvisionedThroughput`/`Archive` date fields to `string | null`, and updated helper signatures (`mapBaseIndex`, `mapGlobalSecondaryIndex`, `mapReplicaDescription`) to accept `Serialized<…>` input.

## Verification

Whole repo, in dependency order:
- `turbo run build` — **27/27 successful**
- `turbo run test` — **50/50 successful**
- `turbo run lint` (tsc + prettier + eslint) — **25/25 successful**

Before this change, type-checking the ec2 scanner reproduced the reported bug as a compile error (`launch-template.ts:188: Property 'toISOString' does not exist on type 'string'`); it is now fixed at both the type and runtime levels.

## Notes

- Draft while it gets a review pass — the change is broad (11 scanner files + the shared-types boundary), though the repo is fully green.
- `sqs` and `sns` timestamp fields were intentionally left as-is: they are string attributes with bespoke handling (sqs hand-builds an epoch-ms string; sns `BeginningArchiveTime` is already a `string`), so a mechanical `tryNormalize*` swap would change their semantics. Worth a separate, deliberate decision.